### PR TITLE
[WAZO-770] relocate: handle pjsip contact without the complete URI

### DIFF
--- a/wazo_calld/plugins/relocates/api.yml
+++ b/wazo_calld/plugins/relocates/api.yml
@@ -187,7 +187,7 @@ definitions:
       destination: line
       location:
         line_id: 14
-        contact: pjsip/zhmz7zfa/sip:5f3ff5ga@127.0.0.1:45190;transport=ws
+        contact: 5f3ff5ga
       completions:
         - "answer"
     required:

--- a/wazo_calld/plugins/relocates/services.py
+++ b/wazo_calld/plugins/relocates/services.py
@@ -62,7 +62,7 @@ class Destination:
 
 class InterfaceDestination(Destination):
 
-    pjsip_contact_re = re.compile(r'''pjsip/[a-z0-9]+/sip:[a-z0-9]+@.*''', re.IGNORECASE)
+    pjsip_contact_re = re.compile(r'pjsip/[a-z0-9]+/sip:[a-z0-9]+@.*', re.IGNORECASE)
 
     def __init__(self, ari, details, initiator_call):
         self.ari = ari

--- a/wazo_calld/plugins/relocates/services.py
+++ b/wazo_calld/plugins/relocates/services.py
@@ -1,12 +1,16 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import re
 import logging
 import threading
 
 from wazo_calld.exceptions import UserPermissionDenied
 from wazo_calld.helpers import ami
-from wazo_calld.helpers.ari_ import Channel
+from wazo_calld.helpers.ari_ import (
+    ARINotFound,
+    Channel,
+)
 from wazo_calld.helpers.confd import User
 from wazo_calld.helpers.exceptions import (
     NotEnoughChannels,
@@ -28,12 +32,13 @@ logger = logging.getLogger(__name__)
 
 class DestinationFactory:
 
-    def __init__(self, amid):
+    def __init__(self, amid, ari):
         self.amid = amid
+        self.ari = ari
 
-    def from_type(self, type_, details):
+    def from_type(self, type_, details, initiator_call):
         if type_ == 'interface':
-            return InterfaceDestination(details)
+            return InterfaceDestination(self.ari, details, initiator_call)
         elif type_ == 'extension':
             return ExtensionDestination(self.amid, details)
         raise NotImplementedError(type_)
@@ -56,11 +61,17 @@ class Destination:
 
 
 class InterfaceDestination(Destination):
-    def __init__(self, details):
+
+    pjsip_contact_re = re.compile(r'''pjsip/[a-z0-9]+/sip:[a-z0-9]+@.*''', re.IGNORECASE)
+
+    def __init__(self, ari, details, initiator_call):
+        self.ari = ari
+        self.initiator_call = initiator_call
+
         interface = details['interface']
 
         if interface.startswith('pjsip/'):
-            self._interface = details.get('contact') or interface
+            self._interface = self._get_pjsip_interface(details)
         else:
             self._interface = interface
 
@@ -71,6 +82,33 @@ class InterfaceDestination(Destination):
 
     def ari_endpoint(self):
         return self._interface
+
+    def _get_pjsip_interface(self, details):
+        contact = details.get('contact')
+        interface = details['interface']
+        if not contact:
+            return interface
+
+        matches = self.pjsip_contact_re.match(contact)
+        if matches:
+            return contact
+
+        _, peer_name = interface.split('/', 1)
+        ast_func = 'PJSIP_DIAL_CONTACTS({})'.format(peer_name)
+        try:
+            response = self.ari.channels.getChannelVar(
+                channelId=self.initiator_call,
+                variable=ast_func,
+            )
+        except ARINotFound as e:
+            raise RelocateCreationError('Cannot find result for {} {}'.format(ast_func, e), details)
+
+        uri_start = 'PJSIP/{}/sip:{}'.format(peer_name, contact)
+        for contact_uri in response['value'].split('&'):
+            if contact_uri.startswith(uri_start):
+                return contact_uri
+
+        raise RelocateCreationError('Failed to find a matching contact', details)
 
 
 class ExtensionDestination(Destination):
@@ -98,7 +136,7 @@ class RelocatesService:
         self.confd_client = confd_client
         self.notifier = notifier
         self.state_factory = state_factory
-        self.destination_factory = DestinationFactory(amid)
+        self.destination_factory = DestinationFactory(amid, ari)
         self.relocates = relocates
         self.duplicate_relocate_lock = threading.Lock()
 
@@ -127,7 +165,11 @@ class RelocatesService:
             raise RelocateCreationError('initiator call not found', details)
 
         try:
-            destination = self.destination_factory.from_type(destination, location)
+            destination = self.destination_factory.from_type(
+                destination,
+                location,
+                initiator_channel,
+            )
         except InvalidDestination:
             details = {'destination': destination, 'location': location}
             raise RelocateCreationError('invalid destination', details)

--- a/wazo_calld/plugins/relocates/services.py
+++ b/wazo_calld/plugins/relocates/services.py
@@ -94,14 +94,15 @@ class InterfaceDestination(Destination):
             return contact
 
         _, peer_name = interface.split('/', 1)
-        ast_func = 'PJSIP_DIAL_CONTACTS({})'.format(peer_name)
+        asterisk_dialplan_function = 'PJSIP_DIAL_CONTACTS({})'.format(peer_name)
         try:
             response = self.ari.channels.getChannelVar(
                 channelId=self.initiator_call,
-                variable=ast_func,
+                variable=asterisk_dialplan_function,
             )
         except ARINotFound as e:
-            raise RelocateCreationError('Cannot find result for {} {}'.format(ast_func, e), details)
+            msg = 'Cannot find result for {} {}'.format(asterisk_dialplan_function, e)
+            raise RelocateCreationError(msg, details)
 
         uri_start = 'PJSIP/{}/sip:{}'.format(peer_name, contact)
         for contact_uri in response['value'].split('&'):

--- a/wazo_calld/plugins/relocates/tests/test_services.py
+++ b/wazo_calld/plugins/relocates/tests/test_services.py
@@ -27,6 +27,13 @@ class TestInterfaceDestination(TestCase):
 
         assert_that(destination.ari_endpoint(), equal_to(interface))
 
+    def test_ari_endpoint_sccp_with_contact(self):
+        interface = 'sccp/foobar'
+        details = {'interface': interface, 'line_id': 42, 'contact': 'invalid'}
+        destination = InterfaceDestination(self.ari, details, s.initiator_call)
+
+        assert_that(destination.ari_endpoint(), equal_to(interface))
+
     def test_ari_endpoint_sip_no_contact(self):
         interface = 'pjsip/foobar'
         details = {'interface': interface, 'line_id': 42}

--- a/wazo_calld/plugins/relocates/tests/test_services.py
+++ b/wazo_calld/plugins/relocates/tests/test_services.py
@@ -1,0 +1,64 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from mock import (
+    Mock,
+    sentinel as s,
+)
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+)
+
+from ..services import InterfaceDestination
+
+
+class TestInterfaceDestination(TestCase):
+
+    def setUp(self):
+        self.ari = Mock()
+
+    def test_ari_endpoint_sccp(self):
+        interface = 'sccp/foobar'
+        details = {'interface': interface, 'line_id': 42}
+        destination = InterfaceDestination(self.ari, details, s.initiator_call)
+
+        assert_that(destination.ari_endpoint(), equal_to(interface))
+
+    def test_ari_endpoint_sip_no_contact(self):
+        interface = 'pjsip/foobar'
+        details = {'interface': interface, 'line_id': 42}
+        destination = InterfaceDestination(self.ari, details, s.initiator_call)
+
+        assert_that(destination.ari_endpoint(), equal_to(interface))
+
+    def test_ari_endpoint_sip_contact_uri(self):
+        contact_uri = 'PJSIP/ycetqvtr/sip:qthehhsk@127.0.0.1:40494;transport=ws'
+        details = {
+            'contact': contact_uri,
+            'interface': 'pjsip/ycetqvtr',
+            'line_id': 18,
+        }
+        destination = InterfaceDestination(self.ari, details, s.initiator_call)
+
+        assert_that(destination.ari_endpoint(), equal_to(contact_uri))
+
+    def test_ari_endpoint_sip_contact_name(self):
+        contact_list = 'PJSIP/ycetqvtr/sip:osm5ohqg@127.0.0.1:54748;transport=ws&PJSIP/ycetqvtr/sip:lg12k0c1@127.0.0.1:54800;transport=ws&PJSIP/ycetqvtr/sip:947ia8sg@127.0.0.1:45270;transport=ws'
+        self.ari.channels.getChannelVar.return_value = {'value': contact_list}
+        details = {
+            'contact': 'lg12k0c1',
+            'interface': 'pjsip/ycetqvtr',
+            'line_id': 18,
+        }
+        destination = InterfaceDestination(self.ari, details, s.initiator_call)
+
+        self.ari.channels.getChannelVar.assert_called_once_with(
+            channelId=s.initiator_call,
+            variable='PJSIP_DIAL_CONTACTS(ycetqvtr)',
+        )
+        assert_that(destination.ari_endpoint(), equal_to(
+            'PJSIP/ycetqvtr/sip:lg12k0c1@127.0.0.1:54800;transport=ws'
+        ))


### PR DESCRIPTION
In the POST /users/me/relocates allow the user to use
"contact": "<contact name>" as well as the old value which is
"contact": "pjsip/<peername>/sip:<contact_name>@<ip>:<port>;transport=<transport>"

The reason behind this change is that the port is only known by Asterisk and is not available on the client side.