### PR TITLE
voicemail: change the ari endpoint from xivo to wazo

### DIFF
--- a/wazo_calld/plugins/voicemails/services.py
+++ b/wazo_calld/plugins/voicemails/services.py
@@ -46,7 +46,7 @@ class VoicemailsService:
             'dest_folder': dest_folder.path.decode('utf-8'),
             'message_id': message_info['id'],
         }
-        self._ari.xivo.moveVoicemailMessage(body=body)
+        self._ari.wazo.moveVoicemailMessage(body=body)
 
     def delete_message(self, voicemail_id, message_id):
         vm_conf = confd.get_voicemail(voicemail_id, self._confd_client)
@@ -57,7 +57,7 @@ class VoicemailsService:
             'folder': message_info['folder'].path.decode('utf-8'),
             'message_id': message_id,
         }
-        self._ari.xivo.deleteVoicemailMessage(body=body)
+        self._ari.wazo.deleteVoicemailMessage(body=body)
 
     def get_user_voicemail_id(self, user_uuid):
         user_voicemail_conf = confd.get_user_voicemail(user_uuid, self._confd_client)


### PR DESCRIPTION
In Asterisk `16.3.0-1~wazo6` the endpoint to manage voicemails was changed from `xivo` to `wazo`

There is a test in the Asterisk repo for the REST API to there are no test in Wazo for this feature.