### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -17,7 +17,6 @@ build-ari: docker-pull
 docker-pull:
 	docker pull p0bailey/docker-flask
 	docker pull python:2.7.13-stretch
-	docker pull swaggerapi/swagger-validator
 	docker pull wazopbx/wait
 	docker pull wazopbx/asterisk
 	docker pull wazopbx/xivo-amid

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -4,11 +4,5 @@ services:
     depends_on:
       - ari
       - calld
-      - swagger-validator
     environment:
-      TARGETS: "ari:5039 calld:9500 swagger-validator:8080"
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - "8080"
+      TARGETS: "ari:5039 calld:9500"

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,13 +1,17 @@
 # Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .helpers.base import IntegrationTest
 from .helpers.wait_strategy import NoWaitStrategy
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(IntegrationTest):
@@ -16,13 +20,7 @@ class TestDocumentation(IntegrationTest):
     wait_strategy = NoWaitStrategy()
 
     def test_documentation_errors(self):
-        calld_port = self.service_port(9500, 'calld')
-        api_url = 'https://localhost:{port}/1.0/api/api.yml'.format(port=calld_port)
+        port = self.service_port(9500, 'calld')
+        api_url = 'https://localhost:{port}/1.0/api/api.yml'.format(port=port)
         api = requests.get(api_url, verify=False)
-        self.validate_api(api)
-
-    def validate_api(self, api):
-        validator_port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=validator_port)
-        response = requests.post(validator_url, data=api)
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -6,7 +6,8 @@ https://github.com/wazo-pbx/xivo-lib-rest-client/archive/master.zip
 docker-compose
 kombu
 nose
-pyhamcrest
+openapi-spec-validator
 psycopg2-binary
+pyhamcrest
 requests
 stevedore  # from wazo-calld-client


### PR DESCRIPTION
reason: openapi-spec-validator catches more errors