### PR TITLE
Transfers: send event when recipient is called

### DIFF
--- a/wazo_calld/plugins/transfers/notifier.py
+++ b/wazo_calld/plugins/transfers/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2016 by Avencall
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -8,7 +8,8 @@ from xivo_bus.resources.calls.transfer import (AbandonTransferEvent,
                                                CancelTransferEvent,
                                                CompleteTransferEvent,
                                                CreateTransferEvent,
-                                               EndTransferEvent)
+                                               EndTransferEvent,
+                                               UpdateTransferEvent,)
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,10 @@ class TransferNotifier:
 
     def created(self, transfer):
         event = CreateTransferEvent(transfer.initiator_uuid, transfer.to_dict())
+        self._bus_producer.publish(event)
+
+    def updated(self, transfer):
+        event = UpdateTransferEvent(transfer.initiator_uuid, transfer.to_dict())
         self._bus_producer.publish(event)
 
     def answered(self, transfer):

--- a/wazo_calld/plugins/transfers/state.py
+++ b/wazo_calld/plugins/transfers/state.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -275,6 +275,7 @@ class TransferStateStarting(TransferState):
                                                                               timeout)
         except TransferCreationError as e:
             logger.error('%s %s', e.message, e.details)
+        self._notifier.updated(self.transfer)
 
         return TransferStateRingback.from_state(self)
 


### PR DESCRIPTION
reason: client app needs the recipient_call as soon as possible