### PR TITLE
Pull request for WAZO-691-event-switchboard-tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 19.09
+
+* The following endpoints now have Wazo-Tenant header to support multi-tenant
+
+  * `GET /1.0/switchboards/{switchboard_uuid}/calls/held`
+  * `PUT /1.0/switchboards/{switchboard_uuid}/calls/held/{call_id}/answer`
+  * `PUT /1.0/switchboards/{switchboard_uuid}/calls/held/{call_id}`
+  * `GET /1.0/switchboards/{switchboard_uuid}/calls/queued`
+  * `PUT /1.0/switchboards/{switchboard_uuid}/calls/queued/{call_id}/answer`
+
+
 ## 19.05
 
 * The following endpoints have been moved to wazo-chatd and deleted from wazo-calld:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,13 @@
   * `GET /1.0/switchboards/{switchboard_uuid}/calls/queued`
   * `PUT /1.0/switchboards/{switchboard_uuid}/calls/queued/{call_id}/answer`
 
-
 ## 19.05
 
 * The following endpoints have been moved to wazo-chatd and deleted from wazo-calld:
 
-    * POST `/1.0/chats
-    * POST `/1.0/users/me/chats`
-    * GET `/1.0/users/me/chats`
-
+  * POST `/1.0/chats
+  * POST `/1.0/users/me/chats`
+  * GET `/1.0/users/me/chats`
 
 ## 19.04
 
@@ -29,17 +27,16 @@
 
 * The following endpoints have been moved to wazo-chatd and deleted from wazo-calld:
 
-    * GET `/1.0/lines/{id}/presences`
+  * GET `/1.0/lines/{id}/presences`
 
-    * GET `/1.0/users/{uuid}/presences`
-    * PUT `/1.0/users/{uuid}/presences`
+  * GET `/1.0/users/{uuid}/presences`
+  * PUT `/1.0/users/{uuid}/presences`
 
-    * GET `/1.0/users/me/presences`
-    * PUT `/1.0/users/me/presences`
+  * GET `/1.0/users/me/presences`
+  * PUT `/1.0/users/me/presences`
 
-    * GET `/1.0/users/me/calls`
-    * DELETE `/1.0/users/me/calls/{id}`
-
+  * GET `/1.0/users/me/calls`
+  * DELETE `/1.0/users/me/calls/{id}`
 
 ## 19.03
 
@@ -48,11 +45,10 @@
   * `POST /conferences/{conference_id}/record`
   * `DELETE /conferences/{conference_id}/record`
 
-Modification of conference mute API:
+* Modification of conference mute API:
 
   * `PUT /conferences/{conference_id}/participants/{participant_id}/mute`
   * `PUT /conferences/{conference_id}/participants/{participant_id}/unmute`
-
 
 ## 19.02
 
@@ -63,13 +59,11 @@ Modification of conference mute API:
   * `POST /conferences/{conference_id}/participants/{participant_id}/mute`
   * `DELETE /conferences/{conference_id}/participants/{participant_id}/mute`
 
-
 ## 19.01
 
 * Add the ability to specify a PJSIP contact on relocates using the `contact` field in the line location body
 
   * `POST /users/me/relocates`
-
 
 ## 18.14
 
@@ -83,12 +77,10 @@ Modification of conference mute API:
   * `POST /applications/{application_uuid}/calls`
   * `POST /applications/{application_uuid}/nodes/{node_uuid}/calls`
 
-
 ## 18.12
 
 * The body of endpoint `GET /status` has been added a new subkey `status`.
 * The applications calls now contain the snoop fields which list snoop membership
-
 
 ## 18.11
 
@@ -102,7 +94,6 @@ Modification of conference mute API:
   * `PUT /applications/{application_uuid}/calls/{call_id}/hold/start`
   * `PUT /applications/{application_uuid}/calls/{call_id}/hold/stop`
 
-
 * New API to snoop on calls
 
   * `GET /applications/{application_uuid}/snoops`
@@ -111,12 +102,10 @@ Modification of conference mute API:
   * `GET /applications/{application_uuid}/snoops/{snoop_uuid}`
   * `DELETE /applications/{application_uuid}/snoops/{snoop_uuid}`
 
-
 * New API to mute calls
 
   * `PUT /applications/{application_uuid}/calls/{call_id}/mute/start`
   * `PUT /applications/{application_uuid}/calls/{call_id}/mute/stop`
-
 
 ## 18.10
 
@@ -136,7 +125,6 @@ Modification of conference mute API:
   * `DELETE /applications/{application_uuid}/nodes/{node_uuid}/calls/{call_id}`
   * `DELETE /applications/{application_uuid}/playbacks/{playback_uuid}`
 
-
 ## 17.17
 
 * New API for relocating calls:
@@ -147,7 +135,6 @@ Modification of conference mute API:
 
   * `dialed_extension`
 
-
 ## 17.15
 
 * New APIs for relocating calls:
@@ -156,13 +143,11 @@ Modification of conference mute API:
   * `GET /users/me/relocates/{relocate_uuid}`
   * `PUT /users/me/relocates/{relocate_uuid}/complete`
 
-
 ## 17.12
 
 * A new API for getting chat history:
 
   * GET `/1.0/users/me/chats`
-
 
 ## 17.05
 
@@ -199,83 +184,79 @@ Modification of conference mute API:
 
 * A new API for managing voicemails messages:
 
-    * GET `/1.0/voicemails/{voicemail_id}`
-    * GET `/1.0/voicemails/{voicemail_id}/folders/{folder_id}`
-    * DELETE `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
-    * GET `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
-    * PUT `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
-    * POST `/1.0/voicemails/{voicemail_id}/messages/{message_id}/recording`
-    * GET `/1.0/users/me/voicemails`
-    * GET `/1.0/users/me/voicemails/folders/{folder_id}`
-    * DELETE `/1.0/users/me/voicemails/messages/{message_id}`
-    * GET `/1.0/users/me/voicemails/messages/{message_id}`
-    * PUT `/1.0/users/me/voicemails/messages/{message_id}`
-    * POST `/1.0/users/me/voicemails/messages/{message_id}/recording`
+  * GET `/1.0/voicemails/{voicemail_id}`
+  * GET `/1.0/voicemails/{voicemail_id}/folders/{folder_id}`
+  * DELETE `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
+  * GET `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
+  * PUT `/1.0/voicemails/{voicemail_id}/messages/{message_id}`
+  * POST `/1.0/voicemails/{voicemail_id}/messages/{message_id}/recording`
+  * GET `/1.0/users/me/voicemails`
+  * GET `/1.0/users/me/voicemails/folders/{folder_id}`
+  * DELETE `/1.0/users/me/voicemails/messages/{message_id}`
+  * GET `/1.0/users/me/voicemails/messages/{message_id}`
+  * PUT `/1.0/users/me/voicemails/messages/{message_id}`
+  * POST `/1.0/users/me/voicemails/messages/{message_id}/recording`
 
 * A new `timeout` parameter has been added to the following URL:
 
-    * POST `/1.0/transfers`
-    * POST `/1.0/users/me/transfers`
+  * POST `/1.0/transfers`
+  * POST `/1.0/users/me/transfers`
 
 * A new `line_id` parameter has been added to the following URL:
 
-    * POST `/1.0/calls`
-    * POST `/1.0/users/me/calls`
-
+  * POST `/1.0/calls`
+  * POST `/1.0/users/me/calls`
 
 ## 16.11
 
 * A new API for getting the status of lines:
 
-    * GET `/1.0/lines/{id}/presences`
-
+  * GET `/1.0/lines/{id}/presences`
 
 ## 16.10
 
 * A new API for checking the status of the daemon:
 
-    * GET `/1.0/status`
-
+  * GET `/1.0/status`
 
 ## 16.09
 
 * A new API for updating user presences:
 
-    * GET `/1.0/users/{uuid}/presences`
-    * PUT `/1.0/users/{uuid}/presences`
-    * GET `/1.0/users/me/presences`
-    * PUT `/1.0/users/me/presences`
+  * GET `/1.0/users/{uuid}/presences`
+  * PUT `/1.0/users/{uuid}/presences`
+  * GET `/1.0/users/me/presences`
+  * PUT `/1.0/users/me/presences`
 
 * New APIs for listing and hanging up calls of a user:
 
-    * GET `/1.0/users/me/calls`
-    * DELETE `/1.0/users/me/calls/{id}`
+  * GET `/1.0/users/me/calls`
+  * DELETE `/1.0/users/me/calls/{id}`
 
 * New APIs for listing, cancelling and completing transfers of a user:
 
-    * GET `/1.0/users/me/transfers`
-    * DELETE `/1.0/users/me/transfers/{transfer_id}`
-    * PUT `/1.0/users/me/transfers/{transfer_id}/complete`
+  * GET `/1.0/users/me/transfers`
+  * DELETE `/1.0/users/me/transfers/{transfer_id}`
+  * PUT `/1.0/users/me/transfers/{transfer_id}/complete`
 
 * POST `/1.0/users/me/transfers` may now return 403 status code.
 * Originates (POST `/*/calls`) now return 400 if an invalid extension is given.
-
 
 ## 16.08
 
 * A new API for making calls from the authenticated user:
 
-    * POST `/1.0/users/me/calls`
+  * POST `/1.0/users/me/calls`
 
 * A new API for sending chat messages:
 
-    * POST `/1.0/chats`
-    * POST `/1.0/users/me/chats`
+  * POST `/1.0/chats`
+  * POST `/1.0/users/me/chats`
 
 * A new parameter for transfer creation (POST `/1.0/transfers`):
 
-    * `variables`
+  * `variables`
 
 * A new API for making transfers from the authenticated user:
 
-    * POST `/1.0/users/me/transfers`
+  * POST `/1.0/users/me/transfers`

--- a/integration_tests/assets/etc/asterisk/ari.conf
+++ b/integration_tests/assets/etc/asterisk/ari.conf
@@ -1,7 +1,7 @@
 [general]
 enabled = yes
 allowed_origins = *
-channelvars = WAZO_SWITCHBOARD_QUEUE,WAZO_SWITCHBOARD_HOLD
+channelvars = WAZO_SWITCHBOARD_QUEUE,WAZO_SWITCHBOARD_HOLD,WAZO_TENANT_UUID
 
 [xivo]
 type = user

--- a/integration_tests/suite/helpers/auth.py
+++ b/integration_tests/suite/helpers/auth.py
@@ -11,9 +11,11 @@ class AuthClient:
         self.port = port
 
     def url(self, *parts):
-        return 'https://{host}:{port}/{path}'.format(host=self.host,
-                                                     port=self.port,
-                                                     path='/'.join(parts))
+        return 'https://{host}:{port}/{path}'.format(
+            host=self.host,
+            port=self.port,
+            path='/'.join(parts)
+        )
 
     def set_token(self, token):
         url = self.url('_set_token')
@@ -24,16 +26,20 @@ class MockUserToken:
 
     def __init__(self, token, user_uuid, acls=None, tenant_uuid=None):
         self._token = token
-        self._auth_id = user_uuid
+        self._user_uuid = user_uuid
         self._acls = acls
         self._tenant_uuid = tenant_uuid
 
     def to_dict(self):
-        result = {'token': self._token,
-                  'auth_id': self._auth_id,
-                  'metadata': {}}
+        result = {
+            'token': self._token,
+            'auth_id': self._user_uuid,
+            'metadata': {},
+        }
         if self._acls:
             result['acls'] = self._acls
         if self._tenant_uuid:
             result['metadata']['tenant_uuid'] = self._tenant_uuid
+        if self._user_uuid:
+            result['metadata']['uuid'] = self._user_uuid
         return result

--- a/integration_tests/suite/helpers/calld.py
+++ b/integration_tests/suite/helpers/calld.py
@@ -515,15 +515,18 @@ class CalldClient:
                               verify=False)
         return result
 
-    def switchboard_queued_calls(self, switchboard_uuid, token=VALID_TOKEN):
-        response = self.get_switchboard_queued_calls_result(switchboard_uuid, token)
+    def switchboard_queued_calls(self, switchboard_uuid, token=VALID_TOKEN, tenant_uuid=None):
+        response = self.get_switchboard_queued_calls_result(switchboard_uuid, token, tenant_uuid)
 
         assert_that(response.status_code, equal_to(200))
         return response.json()
 
-    def get_switchboard_queued_calls_result(self, switchboard_uuid, token=None):
+    def get_switchboard_queued_calls_result(self, switchboard_uuid, token=None, tenant_uuid=None):
         url = self.url('switchboards', switchboard_uuid, 'calls', 'queued')
-        return requests.get(url, headers={'X-Auth-Token': token}, verify=False)
+        headers = {'X-Auth-Token': token}
+        if tenant_uuid:
+            headers['Wazo-Tenant'] = tenant_uuid
+        return requests.get(url, headers=headers, verify=False)
 
     def switchboard_answer_queued_call(self, switchboard_uuid, call_id, token):
         response = self.put_switchboard_queued_call_answer_result(switchboard_uuid, call_id, token)

--- a/integration_tests/suite/helpers/calld.py
+++ b/integration_tests/suite/helpers/calld.py
@@ -545,15 +545,18 @@ class CalldClient:
         url = self.url('switchboards', switchboard_uuid, 'calls', 'held', call_id)
         return requests.put(url, headers={'X-Auth-Token': token}, verify=False)
 
-    def switchboard_held_calls(self, switchboard_uuid, token=VALID_TOKEN):
-        response = self.get_switchboard_held_calls_result(switchboard_uuid, token)
+    def switchboard_held_calls(self, switchboard_uuid, token=VALID_TOKEN, tenant_uuid=None):
+        response = self.get_switchboard_held_calls_result(switchboard_uuid, token, tenant_uuid)
 
         assert_that(response.status_code, equal_to(200))
         return response.json()
 
-    def get_switchboard_held_calls_result(self, switchboard_uuid, token=None):
+    def get_switchboard_held_calls_result(self, switchboard_uuid, token=None, tenant_uuid=None):
         url = self.url('switchboards', switchboard_uuid, 'calls', 'held')
-        return requests.get(url, headers={'X-Auth-Token': token}, verify=False)
+        headers = {'X-Auth-Token': token}
+        if tenant_uuid:
+            headers['Wazo-Tenant'] = tenant_uuid
+        return requests.get(url, headers=headers, verify=False)
 
     def switchboard_answer_held_call(self, switchboard_uuid, call_id, token):
         response = self.put_switchboard_held_call_answer_result(switchboard_uuid, call_id, token)

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -139,8 +139,9 @@ class MockLine:
 
 class MockSwitchboard:
 
-    def __init__(self, uuid, name=None):
+    def __init__(self, uuid, tenant_uuid=None, name=None):
         self._uuid = uuid
+        self._tenant_uuid = tenant_uuid
         self._name = name
 
     def uuid(self):
@@ -149,6 +150,7 @@ class MockSwitchboard:
     def to_dict(self):
         return {
             'uuid': self._uuid,
+            'tenant_uuid': self._tenant_uuid,
             'name': self._name
         }
 

--- a/integration_tests/suite/helpers/constants.py
+++ b/integration_tests/suite/helpers/constants.py
@@ -7,6 +7,7 @@ import os
 ASSET_ROOT = os.path.join(os.path.dirname(__file__), '..', '..', 'assets')
 INVALID_ACL_TOKEN = 'invalid-acl-token'
 VALID_TOKEN = 'valid-token'
+VALID_TENANT = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
 BUS_EXCHANGE_XIVO = Exchange('xivo', type='topic')
 BUS_EXCHANGE_COLLECTD = Exchange('collectd', type='topic', durable=False)
 BUS_URL = 'amqp://guest:guest@localhost:5672//'

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -4,26 +4,30 @@
 import unittest
 
 from ari.exceptions import ARINotInStasis
-from hamcrest import assert_that
-from hamcrest import contains
-from hamcrest import contains_string
-from hamcrest import contains_inanyorder
-from hamcrest import empty
-from hamcrest import equal_to
-from hamcrest import has_entry
-from hamcrest import has_entries
-from hamcrest import has_item
-from hamcrest import has_items
-from hamcrest import is_not
+from hamcrest import (
+    assert_that,
+    contains,
+    contains_string,
+    contains_inanyorder,
+    empty,
+    equal_to,
+    has_entry,
+    has_entries,
+    has_item,
+    has_items,
+    is_not,
+)
 from operator import attrgetter
 from xivo_test_helpers import until
 
 from .helpers.auth import MockUserToken
 from .helpers.base import RealAsteriskIntegrationTest
 from .helpers.constants import VALID_TOKEN
-from .helpers.confd import MockSwitchboard
-from .helpers.confd import MockLine
-from .helpers.confd import MockUser
+from .helpers.confd import (
+    MockSwitchboard,
+    MockLine,
+    MockUser,
+)
 from .helpers.hamcrest_ import HamcrestARIChannel
 
 ENDPOINT_AUTOANSWER = 'Test/integration-caller/autoanswer'
@@ -90,9 +94,11 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
     def test_given_one_call_hungup_then_return_empty_list(self):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(self.channel_is_in_stasis, new_channel.id, tries=2)
         new_channel.hangup()
 
@@ -103,17 +109,26 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
     def test_given_two_call_in_queue_then_list_two_calls(self):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel_1 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
-        new_channel_2 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel_1 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
+        new_channel_2 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         def assert_function():
             calls = self.calld.switchboard_queued_calls(switchboard_uuid)
-            assert_that(calls, has_entry('items', contains_inanyorder(has_entry('id', new_channel_1.id),
-                                                                      has_entry('id', new_channel_2.id))))
+            assert_that(
+                calls,
+                has_entry('items', contains_inanyorder(
+                    has_entry('id', new_channel_1.id),
+                    has_entry('id', new_channel_2.id),
+                ))
+            )
 
         until.assert_(assert_function, tries=3)
 
@@ -126,12 +141,16 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
 
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel_1 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
-        new_channel_2 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel_1 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
+        new_channel_2 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         until.assert_(calls_are_queued, new_channel_1.id, new_channel_2.id, tries=3)
 
@@ -141,58 +160,79 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
 
     def test_given_no_calls_when_new_queued_call_then_bus_event(self):
         switchboard_uuid = 'my-switchboard-uuid'
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         def event_received():
-            assert_that(bus_events.accumulate(),
-                        contains(has_entries({'name': 'switchboard_queued_calls_updated',
-                                              'data': has_entries({
-                                                  'switchboard_uuid': switchboard_uuid,
-                                                  'items': contains(has_entry(
-                                                      'id', new_channel.id,
-                                                  )),
-                                              })})))
+            assert_that(
+                bus_events.accumulate(),
+                contains(has_entries({
+                    'name': 'switchboard_queued_calls_updated',
+                    'data': has_entries({
+                        'switchboard_uuid': switchboard_uuid,
+                        'items': contains(has_entry(
+                            'id', new_channel.id,
+                        )),
+                    })
+                }))
+            )
 
         until.assert_(event_received, tries=3)
 
     def test_given_one_call_queued_when_hangup_then_bus_event(self):
         switchboard_uuid = 'my-switchboard-uuid'
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         until.true(bus_events.accumulate, tries=3)
 
         new_channel.hangup()
 
         def event_received():
-            assert_that(bus_events.accumulate(),
-                        contains(has_entries({'name': 'switchboard_queued_calls_updated',
-                                              'data': has_entries({
-                                                  'switchboard_uuid': switchboard_uuid,
-                                                  'items': is_not(empty()),
-                                              })}),
-                                 has_entries({'name': 'switchboard_queued_calls_updated',
-                                              'data': has_entries({
-                                                  'switchboard_uuid': switchboard_uuid,
-                                                  'items': empty(),
-                                              })})))
+            assert_that(
+                bus_events.accumulate(),
+                contains(
+                    has_entries({
+                        'name': 'switchboard_queued_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': is_not(empty()),
+                        })
+                    }),
+                    has_entries({
+                        'name': 'switchboard_queued_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': empty(),
+                        })
+                    })
+                )
+            )
 
         until.assert_(event_received, tries=3)
 
     def test_given_calld_stopped_and_queued_is_hung_up_when_calld_starts_then_bus_event(self):
         switchboard_uuid = 'my-switchboard-uuid'
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         until.true(bus_events.accumulate, tries=3)
 
@@ -200,17 +240,25 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
             new_channel.hangup()
 
         def event_received():
-            assert_that(bus_events.accumulate(),
-                        has_items(has_entries({'name': 'switchboard_queued_calls_updated',
-                                               'data': has_entries({
-                                                   'switchboard_uuid': switchboard_uuid,
-                                                   'items': is_not(empty()),
-                                               })}),
-                                  has_entries({'name': 'switchboard_queued_calls_updated',
-                                               'data': has_entries({
-                                                   'switchboard_uuid': switchboard_uuid,
-                                                   'items': empty(),
-                                               })})))
+            assert_that(
+                bus_events.accumulate(),
+                has_items(
+                    has_entries({
+                        'name': 'switchboard_queued_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': is_not(empty()),
+                        })
+                    }),
+                    has_entries({
+                        'name': 'switchboard_queued_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': empty(),
+                        })
+                    })
+                )
+            )
         until.assert_(event_received, tries=3)
 
     @unittest.skip
@@ -226,7 +274,9 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
 
     def test_given_no_confd_when_answer_queued_call_then_503(self):
         with self.confd_stopped():
-            result = self.calld.put_switchboard_queued_call_answer_result(UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN)
+            result = self.calld.put_switchboard_queued_call_answer_result(
+                UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN
+            )
 
         assert_that(result.status_code, equal_to(503))
 
@@ -237,10 +287,13 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         switchboard_uuid = UUID_NOT_FOUND
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
-        self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        line = MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test')
+        self.confd.set_lines(line)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
 
         result = self.calld.put_switchboard_queued_call_answer_result(switchboard_uuid, queued_call_id, token)
@@ -270,9 +323,11 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
 
@@ -288,10 +343,13 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid))
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
 
@@ -309,10 +367,13 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
 
@@ -330,11 +391,15 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
 
@@ -363,11 +428,14 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
-                                                  callerId=queued_caller_id)
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            callerId=queued_caller_id,
+        )
         until.true(queued_bus_events.accumulate, tries=3)
         queued_call_id = new_channel.id
         result = self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
@@ -375,16 +443,21 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         operator_channel = self.ari.channels.get(channelId=operator_call_id)
         operator_channel.setChannelVar(variable='XIVO_ORIGINAL_CALLER_ID', value=operator_caller_id, bypassStasis=True)
 
-        assert_that(operator_channel.json, has_entry('caller', has_entries({'name': 'câller',
-                                                                            'number': '1234'})))
+        assert_that(
+            operator_channel.json,
+            has_entry('caller', has_entries({'name': 'câller', 'number': '1234'}))
+        )
 
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
         self.chan_test.answer_channel(operator_channel.id)
         until.true(answered_bus_events.accumulate, tries=3)
 
         operator_channel = self.ari.channels.get(channelId=operator_call_id)
-        assert_that(operator_channel.json, has_entry('caller', has_entries({'name': 'ôperator',
-                                                                            'number': '9876'})))
+        assert_that(
+            operator_channel.json,
+            has_entry('caller', has_entries({'name': 'ôperator', 'number': '9876'}))
+        )
 
     def test_given_operator_is_answering_a_hungup_channel_when_answer_then_operator_is_hungup(self):
         token = 'my-token'
@@ -395,10 +468,13 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator', protocol='test'))
-        bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
         result = self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
@@ -417,17 +493,22 @@ class TestSwitchboardHoldCall(TestSwitchboards):
 
     def test_given_no_confd_when_hold_call_then_503(self):
         with self.confd_stopped():
-            result = self.calld.put_switchboard_held_call_result(UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN)
+            result = self.calld.put_switchboard_held_call_result(
+                UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN
+            )
 
         assert_that(result.status_code, equal_to(503))
 
     def test_given_no_switchboard_when_hold_call_then_404(self):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
 
@@ -455,11 +536,15 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
         result = self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
@@ -483,30 +568,37 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
         until.true(answered_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
 
         self.calld.switchboard_hold_call(switchboard_uuid, queued_call_id)
 
         def event_received():
-            assert_that(held_bus_events.accumulate(),
-                        contains(has_entries({
-                            'name': 'switchboard_held_calls_updated',
-                            'data': has_entries({
-                                'switchboard_uuid': switchboard_uuid,
-                                'items': contains(
-                                    has_entry('id', queued_call_id)
-                                ),
-                            })
-                        })))
+            assert_that(
+                held_bus_events.accumulate(),
+                contains(has_entries({
+                    'name': 'switchboard_held_calls_updated',
+                    'data': has_entries({
+                        'switchboard_uuid': switchboard_uuid,
+                        'items': contains(
+                            has_entry('id', queued_call_id)
+                        ),
+                    })
+                }))
+            )
 
         until.assert_(event_received, tries=3)
 
@@ -519,26 +611,33 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
 
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
         until.true(answered_bus_events.accumulate, tries=3)
 
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, queued_call_id)
         until.true(held_bus_events.accumulate, tries=3)
 
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_answer_queued_call(switchboard_uuid, queued_call_id, token)
         until.true(answered_bus_events.accumulate, tries=3)
 
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, queued_call_id)
         until.true(held_bus_events.accumulate, tries=3)
 
@@ -567,10 +666,13 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
     def test_given_one_call_hungup_then_return_empty_list(self):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         new_channel.hangup()
@@ -582,21 +684,31 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
     def test_given_two_calls_held_then_list_two_calls(self):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel_1 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
-        new_channel_2 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel_1 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
+        new_channel_2 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_1.id)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_2.id)
 
         def assert_function():
             calls = self.calld.switchboard_held_calls(switchboard_uuid)
-            assert_that(calls, has_entry('items', contains_inanyorder(has_entry('id', new_channel_1.id),
-                                                                      has_entry('id', new_channel_2.id))))
+            assert_that(
+                calls,
+                has_entry('items', contains_inanyorder(
+                    has_entry('id', new_channel_1.id),
+                    has_entry('id', new_channel_2.id),
+                ))
+            )
 
         until.assert_(assert_function, tries=3)
 
@@ -609,13 +721,18 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
 
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel_1 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
-        new_channel_2 = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                    app=STASIS_APP,
-                                                    appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel_1 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
+        new_channel_2 = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_1.id)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_2.id)
@@ -628,44 +745,60 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
 
     def test_given_one_call_held_when_hangup_then_bus_event(self):
         switchboard_uuid = 'my-switchboard-uuid'
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
 
         new_channel.hangup()
 
         def event_received():
-            assert_that(held_bus_events.accumulate(),
-                        contains(has_entries({'name': 'switchboard_held_calls_updated',
-                                              'data': has_entries({
-                                                  'switchboard_uuid': switchboard_uuid,
-                                                  'items': is_not(empty())
-                                              })}),
-                                 has_entries({'name': 'switchboard_held_calls_updated',
-                                              'data': has_entries({
-                                                  'switchboard_uuid': switchboard_uuid,
-                                                  'items': empty()
-                                              })})))
+            assert_that(
+                held_bus_events.accumulate(),
+                contains(
+                    has_entries({
+                        'name': 'switchboard_held_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': is_not(empty())
+                        })
+                    }),
+                    has_entries({
+                        'name': 'switchboard_held_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': empty()
+                        })
+                    })
+                )
+            )
 
         until.assert_(event_received, tries=3)
 
     def test_given_calld_stopped_and_held_is_hung_up_when_calld_starts_then_bus_event(self):
         switchboard_uuid = 'my-switchboard-uuid'
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
 
@@ -673,17 +806,25 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
             new_channel.hangup()
 
         def event_received():
-            assert_that(held_bus_events.accumulate(),
-                        has_items(has_entries({'name': 'switchboard_held_calls_updated',
-                                               'data': has_entries({
-                                                   'switchboard_uuid': switchboard_uuid,
-                                                   'items': is_not(empty())
-                                               })}),
-                                  has_entries({'name': 'switchboard_held_calls_updated',
-                                               'data': has_entries({
-                                                   'switchboard_uuid': switchboard_uuid,
-                                                   'items': empty()
-                                               })})))
+            assert_that(
+                held_bus_events.accumulate(),
+                has_items(
+                    has_entries({
+                        'name': 'switchboard_held_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': is_not(empty())
+                        })
+                    }),
+                    has_entries({
+                        'name': 'switchboard_held_calls_updated',
+                        'data': has_entries({
+                            'switchboard_uuid': switchboard_uuid,
+                            'items': empty()
+                        })
+                    })
+                )
+            )
 
         until.assert_(event_received, tries=3)
 
@@ -692,7 +833,9 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
 
     def test_given_no_confd_when_answer_held_call_then_503(self):
         with self.confd_stopped():
-            result = self.calld.put_switchboard_held_call_answer_result(UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN)
+            result = self.calld.put_switchboard_held_call_answer_result(
+                UUID_NOT_FOUND, CALL_ID_NOT_FOUND, token=VALID_TOKEN
+            )
 
         assert_that(result.status_code, equal_to(503))
 
@@ -704,9 +847,11 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
         switchboard_uuid = UUID_NOT_FOUND
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
 
         result = self.calld.put_switchboard_held_call_answer_result(switchboard_uuid, new_channel.id, token)
 
@@ -734,12 +879,16 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id
@@ -756,12 +905,16 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id
@@ -780,12 +933,16 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id
@@ -804,16 +961,20 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
         held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
 
         result = self.calld.switchboard_answer_held_call(switchboard_uuid, held_call_id, token)
 
@@ -840,31 +1001,44 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
-                                                  callerId=held_caller_id)
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            callerId=held_caller_id,
+        )
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id
         result = self.calld.switchboard_answer_held_call(switchboard_uuid, held_call_id, token)
         operator_call_id = result['call_id']
         operator_channel = self.ari.channels.get(channelId=operator_call_id)
-        operator_channel.setChannelVar(variable='XIVO_ORIGINAL_CALLER_ID', value=operator_caller_id, bypassStasis=True)
+        operator_channel.setChannelVar(
+            variable='XIVO_ORIGINAL_CALLER_ID',
+            value=operator_caller_id,
+            bypassStasis=True,
+        )
 
-        assert_that(operator_channel.json, has_entry('caller', has_entries({'name': 'câller',
-                                                                            'number': '1234'})))
+        assert_that(
+            operator_channel.json,
+            has_entry('caller', has_entries({'name': 'câller', 'number': '1234'}))
+        )
 
-        answered_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.*.answer.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.*.answer.updated'.format(uuid=switchboard_uuid)
+        answered_bus_events = self.bus.accumulator(routing_key)
         self.chan_test.answer_channel(operator_channel.id)
         until.true(answered_bus_events.accumulate, tries=3)
 
         operator_channel = self.ari.channels.get(channelId=operator_call_id)
-        assert_that(operator_channel.json, has_entry('caller', has_entries({'name': 'ôperator',
-                                                                            'number': '9876'})))
+        assert_that(
+            operator_channel.json,
+            has_entry('caller', has_entries({'name': 'ôperator', 'number': '9876'}))
+        )
 
     def test_given_operator_is_answering_a_hungup_channel_when_answer_then_operator_is_hungup(self):
         token = 'my-token'
@@ -875,12 +1049,16 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator', protocol='test'))
-        queued_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
-        new_channel = self.ari.channels.originate(endpoint=ENDPOINT_AUTOANSWER,
-                                                  app=STASIS_APP,
-                                                  appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid])
+        routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
+        queued_bus_events = self.bus.accumulator(routing_key)
+        new_channel = self.ari.channels.originate(
+            endpoint=ENDPOINT_AUTOANSWER,
+            app=STASIS_APP,
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+        )
         until.true(queued_bus_events.accumulate, tries=3)
-        held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
+        routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
+        held_bus_events = self.bus.accumulator(routing_key)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
         until.true(held_bus_events.accumulate, tries=3)
         held_call_id = new_channel.id

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -111,7 +111,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(self.channel_is_in_stasis, new_channel.id, tries=2)
         new_channel.hangup()
@@ -126,12 +126,12 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel_1 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         new_channel_2 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         def assert_function():
@@ -158,12 +158,12 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel_1 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         new_channel_2 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         until.assert_(calls_are_queued, new_channel_1.id, new_channel_2.id, tries=3)
@@ -180,7 +180,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         def event_received():
@@ -207,7 +207,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         until.true(bus_events.accumulate, tries=3)
@@ -245,7 +245,7 @@ class TestSwitchboardCallsQueued(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         until.true(bus_events.accumulate, tries=3)
@@ -306,7 +306,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
 
@@ -340,7 +340,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -362,7 +362,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -386,7 +386,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -412,7 +412,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -447,7 +447,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
             callerId=queued_caller_id,
         )
         until.true(queued_bus_events.accumulate, tries=3)
@@ -487,7 +487,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -521,7 +521,7 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -565,7 +565,7 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -595,7 +595,7 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -638,7 +638,7 @@ class TestSwitchboardHoldCall(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -706,7 +706,7 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel.id)
@@ -724,12 +724,12 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         new_channel_1 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         new_channel_2 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_1.id)
@@ -761,12 +761,12 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         new_channel_1 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         new_channel_2 = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         self.calld.switchboard_hold_call(switchboard_uuid, new_channel_1.id)
@@ -786,7 +786,7 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         until.true(queued_bus_events.accumulate, tries=3)
@@ -828,7 +828,7 @@ class TestSwitchboardCallsHeld(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         until.true(queued_bus_events.accumulate, tries=3)
@@ -885,7 +885,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
 
         result = self.calld.put_switchboard_held_call_answer_result(switchboard_uuid, new_channel.id, token)
@@ -919,7 +919,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -945,7 +945,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -973,7 +973,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -1001,7 +1001,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
@@ -1041,7 +1041,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
             callerId=held_caller_id,
         )
         until.true(queued_bus_events.accumulate, tries=3)
@@ -1089,7 +1089,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, VALID_TENANT, switchboard_uuid],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -878,14 +878,14 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         self.confd.set_lines(MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test'))
         switchboard_uuid = UUID_NOT_FOUND
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
 
         result = self.calld.put_switchboard_held_call_answer_result(switchboard_uuid, new_channel.id, token)
@@ -897,7 +897,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -911,7 +911,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
     def test_given_token_with_no_user_when_answer_then_400(self):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
@@ -919,7 +919,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -936,7 +936,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
     def test_given_operator_has_no_line_when_answer_then_400(self):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid))
@@ -945,7 +945,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -963,7 +963,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -973,7 +973,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
@@ -991,7 +991,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -1001,7 +1001,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         held_bus_events = self.bus.accumulator('switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid))
@@ -1031,7 +1031,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         line_id = 'my-line-id'
         held_caller_id = '"câller" <1234>'.encode('utf-8')
         operator_caller_id = '"ôperator" <9876>'.encode('utf-8')
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -1041,7 +1041,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
             callerId=held_caller_id,
         )
         until.true(queued_bus_events.accumulate, tries=3)
@@ -1079,7 +1079,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -1089,7 +1089,7 @@ class TestSwitchboardCallsHeldAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         until.true(queued_bus_events.accumulate, tries=3)
         routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)

--- a/integration_tests/suite/test_switchboards.py
+++ b/integration_tests/suite/test_switchboards.py
@@ -298,7 +298,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = UUID_NOT_FOUND
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
         line = MockLine(id=line_id, name='switchboard-operator/autoanswer', protocol='test')
@@ -306,7 +306,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
 
@@ -319,7 +319,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -333,14 +333,14 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
     def test_given_token_with_no_user_when_answer_then_400(self):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         bus_events = self.bus.accumulator('switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid))
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -353,7 +353,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
     def test_given_operator_has_no_line_when_answer_then_400(self):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid))
@@ -362,7 +362,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -376,7 +376,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -386,7 +386,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)
@@ -400,7 +400,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -412,7 +412,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
         until.true(queued_bus_events.accumulate, tries=3)
@@ -437,7 +437,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         line_id = 'my-line-id'
         queued_caller_id = '"câller" <1234>'.encode('utf-8')
         operator_caller_id = '"ôperator" <9876>'.encode('utf-8')
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -447,7 +447,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
             callerId=queued_caller_id,
         )
         until.true(queued_bus_events.accumulate, tries=3)
@@ -477,7 +477,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         token = 'my-token'
         user_uuid = 'my-user-uuid'
         line_id = 'my-line-id'
-        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid))
+        self.auth.set_token(MockUserToken(token, user_uuid=user_uuid, tenant_uuid=VALID_TENANT))
         switchboard_uuid = 'my-switchboard-uuid'
         self.confd.set_switchboards(MockSwitchboard(uuid=switchboard_uuid))
         self.confd.set_users(MockUser(uuid=user_uuid, line_ids=[line_id]))
@@ -487,7 +487,7 @@ class TestSwitchboardCallsQueuedAnswer(TestSwitchboards):
         new_channel = self.ari.channels.originate(
             endpoint=ENDPOINT_AUTOANSWER,
             app=STASIS_APP,
-            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid],
+            appArgs=[STASIS_APP_INSTANCE, STASIS_APP_QUEUE, switchboard_uuid, VALID_TENANT],
         )
         queued_call_id = new_channel.id
         until.true(bus_events.accumulate, tries=3)

--- a/wazo_calld/plugins/api/api.yml
+++ b/wazo_calld/plugins/api/api.yml
@@ -57,3 +57,9 @@ parameters:
     in: query
     description: The token's ID
     type: string
+  TenantUUID:
+    name: Wazo-Tenant
+    type: string
+    in: header
+    description: "The tenant's UUID, defining the ownership of a given resource."
+    required: false

--- a/wazo_calld/plugins/switchboards/api.yml
+++ b/wazo_calld/plugins/switchboards/api.yml
@@ -8,6 +8,7 @@ paths:
       tags:
         - switchboards
       parameters:
+        - $ref: '#/parameters/TenantUUID'
         - $ref: '#/parameters/SwitchboardUUID'
       responses:
         '200':
@@ -27,6 +28,7 @@ paths:
       tags:
         - switchboards
       parameters:
+        - $ref: '#/parameters/TenantUUID'
         - $ref: '#/parameters/SwitchboardUUID'
         - $ref: '#/parameters/CallID'
       responses:
@@ -49,6 +51,7 @@ paths:
       tags:
         - switchboards
       parameters:
+        - $ref: '#/parameters/TenantUUID'
         - $ref: '#/parameters/SwitchboardUUID'
       responses:
         '200':
@@ -69,6 +72,7 @@ paths:
       tags:
         - switchboards
       parameters:
+        - $ref: '#/parameters/TenantUUID'
         - $ref: '#/parameters/SwitchboardUUID'
         - $ref: '#/parameters/CallID'
       responses:
@@ -89,6 +93,7 @@ paths:
       tags:
         - switchboards
       parameters:
+        - $ref: '#/parameters/TenantUUID'
         - $ref: '#/parameters/SwitchboardUUID'
         - $ref: '#/parameters/CallID'
       responses:

--- a/wazo_calld/plugins/switchboards/confd.py
+++ b/wazo_calld/plugins/switchboards/confd.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from requests import HTTPError
@@ -9,13 +9,14 @@ from wazo_calld.helpers.confd import not_found
 
 
 class Switchboard:
-    def __init__(self, uuid, confd_client):
+    def __init__(self, tenant_uuid, uuid, confd_client):
+        self.tenant_uuid = tenant_uuid
         self.uuid = uuid
         self._confd = confd_client
 
     def exists(self):
         try:
-            self._confd.switchboards.get(self.uuid)
+            self._confd.switchboards.get(self.uuid, tenant_uuid=self.tenant_uuid)
         except HTTPError as e:
             if not_found(e):
                 return False

--- a/wazo_calld/plugins/switchboards/exceptions.py
+++ b/wazo_calld/plugins/switchboards/exceptions.py
@@ -1,7 +1,20 @@
-# Copyright 2017-2018 The Wazo Authors  (see AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_calld.exceptions import APIException
+
+
+class NoSuchConfdUser(APIException):
+
+    def __init__(self, user_uuid):
+        super().__init__(
+            status_code=400,
+            message='No such confd user for the given authentication user',
+            error_id='no-such-confd-user',
+            details={
+                'user_uuid': user_uuid
+            }
+        )
 
 
 class NoSuchSwitchboard(APIException):

--- a/wazo_calld/plugins/switchboards/notifier.py
+++ b/wazo_calld/plugins/switchboards/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -19,7 +19,7 @@ class SwitchboardsNotifier:
     def __init__(self, bus):
         self._bus = bus
 
-    def queued_calls(self, switchboard_uuid, calls):
+    def queued_calls(self, tenant_uuid, switchboard_uuid, calls):
         body = {
             'switchboard_uuid': switchboard_uuid,
             'items': queued_call_schema.dump(calls, many=True).data

--- a/wazo_calld/plugins/switchboards/notifier.py
+++ b/wazo_calld/plugins/switchboards/notifier.py
@@ -87,7 +87,7 @@ class SwitchboardsNotifier:
         event.routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
         self._bus.publish(event)
 
-    def held_call_answered(self, switchboard_uuid, operator_call_id, held_call_id):
+    def held_call_answered(self, tenant_uuid, switchboard_uuid, operator_call_id, held_call_id):
         logger.debug(
             'Held call %s in switchboard %s answered by %s',
             held_call_id,

--- a/wazo_calld/plugins/switchboards/notifier.py
+++ b/wazo_calld/plugins/switchboards/notifier.py
@@ -37,7 +37,8 @@ class SwitchboardsNotifier:
             ),
         )
         event.routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
-        self._bus.publish(event)
+        headers = {'tenant_uuid': tenant_uuid}
+        self._bus.publish(event, headers=headers)
 
     def queued_call_answered(self, tenant_uuid, switchboard_uuid, operator_call_id, queued_call_id):
         logger.debug(
@@ -65,7 +66,8 @@ class SwitchboardsNotifier:
             required_acl=required_acl,
         )
         event.routing_key = routing_key
-        self._bus.publish(event)
+        headers = {'tenant_uuid': tenant_uuid}
+        self._bus.publish(event, headers=headers)
 
     def held_calls(self, tenant_uuid, switchboard_uuid, calls):
         body = {
@@ -85,7 +87,8 @@ class SwitchboardsNotifier:
             ),
         )
         event.routing_key = 'switchboards.{uuid}.calls.held.updated'.format(uuid=switchboard_uuid)
-        self._bus.publish(event)
+        headers = {'tenant_uuid': tenant_uuid}
+        self._bus.publish(event, headers=headers)
 
     def held_call_answered(self, tenant_uuid, switchboard_uuid, operator_call_id, held_call_id):
         logger.debug(
@@ -113,4 +116,5 @@ class SwitchboardsNotifier:
             required_acl=required_acl,
         )
         event.routing_key = routing_key
-        self._bus.publish(event)
+        headers = {'tenant_uuid': tenant_uuid}
+        self._bus.publish(event, headers=headers)

--- a/wazo_calld/plugins/switchboards/notifier.py
+++ b/wazo_calld/plugins/switchboards/notifier.py
@@ -39,7 +39,7 @@ class SwitchboardsNotifier:
         event.routing_key = 'switchboards.{uuid}.calls.queued.updated'.format(uuid=switchboard_uuid)
         self._bus.publish(event)
 
-    def queued_call_answered(self, switchboard_uuid, operator_call_id, queued_call_id):
+    def queued_call_answered(self, tenant_uuid, switchboard_uuid, operator_call_id, queued_call_id):
         logger.debug(
             'Queued call %s in switchboard %s answered by %s',
             queued_call_id,

--- a/wazo_calld/plugins/switchboards/notifier.py
+++ b/wazo_calld/plugins/switchboards/notifier.py
@@ -67,7 +67,7 @@ class SwitchboardsNotifier:
         event.routing_key = routing_key
         self._bus.publish(event)
 
-    def held_calls(self, switchboard_uuid, calls):
+    def held_calls(self, tenant_uuid, switchboard_uuid, calls):
         body = {
             'switchboard_uuid': switchboard_uuid,
             'items': held_call_schema.dump(calls, many=True).data

--- a/wazo_calld/plugins/switchboards/plugin.py
+++ b/wazo_calld/plugins/switchboards/plugin.py
@@ -1,7 +1,6 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_auth_client import Client as AuthClient
 from wazo_confd_client import Client as ConfdClient
 
 from wazo_calld.ari_ import DEFAULT_APPLICATION_NAME
@@ -27,10 +26,8 @@ class Plugin:
         config = dependencies['config']
         token_changed_subscribe = dependencies['token_changed_subscribe']
 
-        auth_client = AuthClient(**config['auth'])
         confd_client = ConfdClient(**config['confd'])
 
-        token_changed_subscribe(auth_client.set_token)
         token_changed_subscribe(confd_client.set_token)
 
         switchboards_notifier = SwitchboardsNotifier(bus_publisher)
@@ -48,7 +45,7 @@ class Plugin:
         api.add_resource(
             SwitchboardCallQueuedAnswerResource,
             '/switchboards/<switchboard_uuid>/calls/queued/<call_id>/answer',
-            resource_class_args=[auth_client, switchboards_service],
+            resource_class_args=[switchboards_service],
         )
         api.add_resource(
             SwitchboardCallsHeldResource,
@@ -63,5 +60,5 @@ class Plugin:
         api.add_resource(
             SwitchboardCallHeldAnswerResource,
             '/switchboards/<switchboard_uuid>/calls/held/<call_id>/answer',
-            resource_class_args=[auth_client, switchboards_service],
+            resource_class_args=[switchboards_service],
         )

--- a/wazo_calld/plugins/switchboards/resources.py
+++ b/wazo_calld/plugins/switchboards/resources.py
@@ -1,10 +1,14 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from xivo.tenant_flask_helpers import Tenant
+
 from marshmallow import Schema, fields
 
-from wazo_calld.auth import get_token_user_uuid_from_request
-from wazo_calld.auth import required_acl
+from wazo_calld.auth import (
+    get_token_user_uuid_from_request,
+    required_acl,
+)
 from wazo_calld.http import AuthResource
 
 
@@ -33,7 +37,8 @@ class SwitchboardCallsQueuedResource(AuthResource):
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.queued.read')
     def get(self, switchboard_uuid):
-        calls = self._service.queued_calls(switchboard_uuid)
+        tenant = Tenant.autodetect()
+        calls = self._service.queued_calls(tenant.uuid, switchboard_uuid)
 
         return {'items': queued_call_schema.dump(calls, many=True).data}
 

--- a/wazo_calld/plugins/switchboards/resources.py
+++ b/wazo_calld/plugins/switchboards/resources.py
@@ -68,7 +68,8 @@ class SwitchboardCallHeldResource(AuthResource):
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.held.{call_id}.update')
     def put(self, switchboard_uuid, call_id):
-        self._service.hold_call(switchboard_uuid, call_id)
+        tenant = Tenant.autodetect()
+        self._service.hold_call(tenant.uuid, switchboard_uuid, call_id)
         return '', 204
 
 
@@ -79,7 +80,8 @@ class SwitchboardCallsHeldResource(AuthResource):
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.held.read')
     def get(self, switchboard_uuid):
-        calls = self._service.held_calls(switchboard_uuid)
+        tenant = Tenant.autodetect()
+        calls = self._service.held_calls(tenant.uuid, switchboard_uuid)
 
         return {'items': held_call_schema.dump(calls, many=True).data}
 

--- a/wazo_calld/plugins/switchboards/resources.py
+++ b/wazo_calld/plugins/switchboards/resources.py
@@ -1,14 +1,11 @@
 # Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from xivo.tenant_flask_helpers import Tenant
+from xivo.tenant_flask_helpers import Tenant, token
 
 from marshmallow import Schema, fields
 
-from wazo_calld.auth import (
-    get_token_user_uuid_from_request,
-    required_acl,
-)
+from wazo_calld.auth import required_acl
 from wazo_calld.http import AuthResource
 
 
@@ -45,14 +42,13 @@ class SwitchboardCallsQueuedResource(AuthResource):
 
 class SwitchboardCallQueuedAnswerResource(AuthResource):
 
-    def __init__(self, auth_client, switchboards_service):
-        self._auth_client = auth_client
+    def __init__(self, switchboards_service):
         self._service = switchboards_service
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.queued.{call_id}.answer.update')
     def put(self, switchboard_uuid, call_id):
         tenant = Tenant.autodetect()
-        user_uuid = get_token_user_uuid_from_request(self._auth_client)
+        user_uuid = token.user_uuid
 
         call_id = self._service.answer_queued_call(
             tenant.uuid, switchboard_uuid, call_id, user_uuid
@@ -88,14 +84,13 @@ class SwitchboardCallsHeldResource(AuthResource):
 
 class SwitchboardCallHeldAnswerResource(AuthResource):
 
-    def __init__(self, auth_client, switchboards_service):
-        self._auth_client = auth_client
+    def __init__(self, switchboards_service):
         self._service = switchboards_service
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.held.{call_id}.answer.update')
     def put(self, switchboard_uuid, call_id):
         tenant = Tenant.autodetect()
-        user_uuid = get_token_user_uuid_from_request(self._auth_client)
+        user_uuid = token.user_uuid
 
         call_id = self._service.answer_held_call(tenant.uuid, switchboard_uuid, call_id, user_uuid)
 

--- a/wazo_calld/plugins/switchboards/resources.py
+++ b/wazo_calld/plugins/switchboards/resources.py
@@ -94,8 +94,9 @@ class SwitchboardCallHeldAnswerResource(AuthResource):
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.held.{call_id}.answer.update')
     def put(self, switchboard_uuid, call_id):
+        tenant = Tenant.autodetect()
         user_uuid = get_token_user_uuid_from_request(self._auth_client)
 
-        call_id = self._service.answer_held_call(switchboard_uuid, call_id, user_uuid)
+        call_id = self._service.answer_held_call(tenant.uuid, switchboard_uuid, call_id, user_uuid)
 
         return {'call_id': call_id}, 200

--- a/wazo_calld/plugins/switchboards/resources.py
+++ b/wazo_calld/plugins/switchboards/resources.py
@@ -51,9 +51,12 @@ class SwitchboardCallQueuedAnswerResource(AuthResource):
 
     @required_acl('calld.switchboards.{switchboard_uuid}.calls.queued.{call_id}.answer.update')
     def put(self, switchboard_uuid, call_id):
+        tenant = Tenant.autodetect()
         user_uuid = get_token_user_uuid_from_request(self._auth_client)
 
-        call_id = self._service.answer_queued_call(switchboard_uuid, call_id, user_uuid)
+        call_id = self._service.answer_queued_call(
+            tenant.uuid, switchboard_uuid, call_id, user_uuid
+        )
 
         return {'call_id': call_id}, 200
 

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -103,7 +103,7 @@ class SwitchboardsService:
         channel = self._ari.channels.originate(
             endpoint=endpoint,
             app=DEFAULT_APPLICATION_NAME,
-            appArgs=['switchboard', 'switchboard_answer', switchboard_uuid, queued_call_id],
+            appArgs=['switchboard', 'switchboard_answer', switchboard_uuid, tenant_uuid, queued_call_id],
             callerId=caller_id,
             originator=queued_call_id,
             variables={'variables': AUTO_ANSWER_VARIABLES},

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -111,8 +111,8 @@ class SwitchboardsService:
 
         return channel.id
 
-    def hold_call(self, switchboard_uuid, call_id):
-        if not Switchboard(switchboard_uuid, self._confd).exists():
+    def hold_call(self, tenant_uuid, switchboard_uuid, call_id):
+        if not Switchboard(tenant_uuid, switchboard_uuid, self._confd).exists():
             raise NoSuchSwitchboard(switchboard_uuid)
 
         try:
@@ -134,9 +134,10 @@ class SwitchboardsService:
 
         hold_bridge.addChannel(channel=channel_to_hold.id)
         channel_to_hold.setChannelVar(variable='WAZO_SWITCHBOARD_HOLD', value=switchboard_uuid)
+        channel_to_hold.setChannelVar(variable='WAZO_TENANT_UUID', value=tenant_uuid)
 
-        held_calls = self.held_calls(switchboard_uuid)
-        self._notifier.held_calls(switchboard_uuid, held_calls)
+        held_calls = self.held_calls(tenant_uuid, switchboard_uuid)
+        self._notifier.held_calls(tenant_uuid, switchboard_uuid, held_calls)
 
         for previous_bridge in previous_bridges:
             try:
@@ -152,8 +153,8 @@ class SwitchboardsService:
                     except ARINotFound:
                         pass
 
-    def held_calls(self, switchboard_uuid):
-        if not Switchboard(switchboard_uuid, self._confd).exists():
+    def held_calls(self, tenant_uuid, switchboard_uuid):
+        if not Switchboard(tenant_uuid, switchboard_uuid, self._confd).exists():
             raise NoSuchSwitchboard(switchboard_uuid)
 
         bridge_id = BRIDGE_HOLD_ID.format(uuid=switchboard_uuid)

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -176,8 +176,8 @@ class SwitchboardsService:
             result.append(call)
         return result
 
-    def answer_held_call(self, switchboard_uuid, held_call_id, user_uuid):
-        if not Switchboard(switchboard_uuid, self._confd).exists():
+    def answer_held_call(self, tenant_uuid, switchboard_uuid, held_call_id, user_uuid):
+        if not Switchboard(tenant_uuid, switchboard_uuid, self._confd).exists():
             raise NoSuchSwitchboard(switchboard_uuid)
 
         try:
@@ -185,7 +185,7 @@ class SwitchboardsService:
         except ARINotFound:
             raise NoSuchCall(held_call_id)
 
-        endpoint = User(user_uuid, self._confd).main_line().interface_autoanswer()
+        endpoint = User(user_uuid, self._confd, tenant_uuid=tenant_uuid).main_line().interface_autoanswer()
         caller_id = assemble_caller_id(
             held_channel.json['caller']['name'],
             held_channel.json['caller']['number'],
@@ -194,7 +194,7 @@ class SwitchboardsService:
         channel = self._ari.channels.originate(
             endpoint=endpoint,
             app=DEFAULT_APPLICATION_NAME,
-            appArgs=['switchboard', 'switchboard_unhold', switchboard_uuid, held_call_id],
+            appArgs=['switchboard', 'switchboard_unhold', switchboard_uuid, tenant_uuid, held_call_id],
             callerId=caller_id,
             variables={'variables': AUTO_ANSWER_VARIABLES},
         )

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -85,8 +85,8 @@ class SwitchboardsService:
         calls = self.queued_calls(tenant_uuid, switchboard_uuid)
         self._notifier.queued_calls(tenant_uuid, switchboard_uuid, calls)
 
-    def answer_queued_call(self, switchboard_uuid, queued_call_id, user_uuid):
-        if not Switchboard(switchboard_uuid, self._confd).exists():
+    def answer_queued_call(self, tenant_uuid, switchboard_uuid, queued_call_id, user_uuid):
+        if not Switchboard(tenant_uuid, switchboard_uuid, self._confd).exists():
             raise NoSuchSwitchboard(switchboard_uuid)
 
         try:
@@ -94,7 +94,7 @@ class SwitchboardsService:
         except ARINotFound:
             raise NoSuchCall(queued_call_id)
 
-        endpoint = User(user_uuid, self._confd).main_line().interface_autoanswer()
+        endpoint = User(user_uuid, self._confd, tenant_uuid=tenant_uuid).main_line().interface_autoanswer()
         caller_id = assemble_caller_id(
             queued_channel.json['caller']['name'],
             queued_channel.json['caller']['number']

--- a/wazo_calld/plugins/switchboards/services.py
+++ b/wazo_calld/plugins/switchboards/services.py
@@ -110,7 +110,7 @@ class SwitchboardsService:
         channel = self._ari.channels.originate(
             endpoint=endpoint,
             app=DEFAULT_APPLICATION_NAME,
-            appArgs=['switchboard', 'switchboard_answer', switchboard_uuid, tenant_uuid, queued_call_id],
+            appArgs=['switchboard', 'switchboard_answer', tenant_uuid, switchboard_uuid, queued_call_id],
             callerId=caller_id,
             originator=queued_call_id,
             variables={'variables': AUTO_ANSWER_VARIABLES},
@@ -206,7 +206,7 @@ class SwitchboardsService:
         channel = self._ari.channels.originate(
             endpoint=endpoint,
             app=DEFAULT_APPLICATION_NAME,
-            appArgs=['switchboard', 'switchboard_unhold', switchboard_uuid, tenant_uuid, held_call_id],
+            appArgs=['switchboard', 'switchboard_unhold', tenant_uuid, switchboard_uuid, held_call_id],
             callerId=caller_id,
             variables={'variables': AUTO_ANSWER_VARIABLES},
         )

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -37,8 +37,8 @@ class SwitchboardsStasis:
 
     def notify_all_switchboard_held(self):
         for switchboard in self._confd.switchboards.list(recurse=True)['items']:
-            held_calls = self._service.held_calls(switchboard['uuid'])
-            self._notifier.held_calls(switchboard['uuid'], held_calls)
+            held_calls = self._service.held_calls(switchboard['tenant_uuid'], switchboard['uuid'])
+            self._notifier.held_calls(switchboard['tenant_uuid'], switchboard['uuid'], held_calls)
 
     def stasis_start(self, event_objects, event):
         if len(event['args']) < 2:
@@ -146,10 +146,11 @@ class SwitchboardsStasis:
 
     def unhold(self, channel, event):
         switchboard_uuid = channel.json['channelvars']['WAZO_SWITCHBOARD_HOLD']
+        tenant_uuid = channel.json['channelvars']['WAZO_TENANT_UUID']
 
         try:
-            held_calls = self._service.held_calls(switchboard_uuid)
+            held_calls = self._service.held_calls(tenant_uuid, switchboard_uuid)
         except NoSuchSwitchboard:
             return
 
-        self._notifier.held_calls(switchboard_uuid, held_calls)
+        self._notifier.held_calls(tenant_uuid, switchboard_uuid, held_calls)

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -101,7 +101,8 @@ class SwitchboardsStasis:
     def _stasis_start_answer_held(self, event_objects, event):
         try:
             switchboard_uuid = event['args'][2]
-            held_channel_id = event['args'][3]
+            tenant_uuid = event['args'][3]
+            held_channel_id = event['args'][4]
         except IndexError:
             logger.warning('Ignoring invalid StasisStart event %s', event)
             return
@@ -131,7 +132,9 @@ class SwitchboardsStasis:
         bridge.addChannel(channel=held_channel_id)
         bridge.addChannel(channel=operator_channel.id)
 
-        self._notifier.held_call_answered(switchboard_uuid, operator_channel.id, held_channel_id)
+        self._notifier.held_call_answered(
+            tenant_uuid, switchboard_uuid, operator_channel.id, held_channel_id
+        )
 
     def unqueue(self, channel, event):
         switchboard_uuid = channel.json['channelvars']['WAZO_SWITCHBOARD_QUEUE']

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -20,8 +20,12 @@ class SwitchboardsStasis:
         self._service = switchboard_service
 
     def subscribe(self):
-        self._ari.on_application_registered(DEFAULT_APPLICATION_NAME, self.notify_all_switchboard_queued)
-        self._ari.on_application_registered(DEFAULT_APPLICATION_NAME, self.notify_all_switchboard_held)
+        self._ari.on_application_registered(
+            DEFAULT_APPLICATION_NAME, self.notify_all_switchboard_queued
+        )
+        self._ari.on_application_registered(
+            DEFAULT_APPLICATION_NAME, self.notify_all_switchboard_held
+        )
         self._ari.on_channel_event('StasisStart', self.stasis_start)
         self._ari.on_channel_event('ChannelLeftBridge', self.unqueue)
         self._ari.on_channel_event('ChannelLeftBridge', self.unhold)
@@ -76,8 +80,12 @@ class SwitchboardsStasis:
 
         operator_channel.answer()
         try:
-            operator_original_caller_id = operator_channel.getChannelVar(variable='XIVO_ORIGINAL_CALLER_ID')['value'].encode('utf-8')
-            operator_channel.setChannelVar(variable='CALLERID(all)', value=operator_original_caller_id)
+            operator_original_caller_id = operator_channel.getChannelVar(
+                variable='XIVO_ORIGINAL_CALLER_ID'
+            )['value'].encode('utf-8')
+            operator_channel.setChannelVar(
+                variable='CALLERID(all)', value=operator_original_caller_id
+            )
         except ARINotFound:
             pass
 
@@ -85,7 +93,9 @@ class SwitchboardsStasis:
         bridge.addChannel(channel=queued_channel_id)
         bridge.addChannel(channel=operator_channel.id)
 
-        self._notifier.queued_call_answered(switchboard_uuid, operator_channel.id, queued_channel_id)
+        self._notifier.queued_call_answered(
+            switchboard_uuid, operator_channel.id, queued_channel_id
+        )
 
     def _stasis_start_answer_held(self, event_objects, event):
         try:
@@ -107,8 +117,12 @@ class SwitchboardsStasis:
 
         operator_channel.answer()
         try:
-            operator_original_caller_id = operator_channel.getChannelVar(variable='XIVO_ORIGINAL_CALLER_ID')['value'].encode('utf-8')
-            operator_channel.setChannelVar(variable='CALLERID(all)', value=operator_original_caller_id)
+            operator_original_caller_id = operator_channel.getChannelVar(
+                variable='XIVO_ORIGINAL_CALLER_ID'
+            )['value'].encode('utf-8')
+            operator_channel.setChannelVar(
+                variable='CALLERID(all)', value=operator_original_caller_id
+            )
         except ARINotFound:
             pass
 

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -64,7 +64,8 @@ class SwitchboardsStasis:
     def _stasis_start_answer(self, event_objects, event):
         try:
             switchboard_uuid = event['args'][2]
-            queued_channel_id = event['args'][3]
+            tenant_uuid = event['args'][3]
+            queued_channel_id = event['args'][4]
         except IndexError:
             logger.warning('Ignoring invalid StasisStart event %s', event)
             return
@@ -95,7 +96,7 @@ class SwitchboardsStasis:
         bridge.addChannel(channel=operator_channel.id)
 
         self._notifier.queued_call_answered(
-            switchboard_uuid, operator_channel.id, queued_channel_id
+            tenant_uuid, switchboard_uuid, operator_channel.id, queued_channel_id
         )
 
     def _stasis_start_answer_held(self, event_objects, event):

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -31,12 +31,12 @@ class SwitchboardsStasis:
         self._ari.on_channel_event('ChannelLeftBridge', self.unhold)
 
     def notify_all_switchboard_queued(self):
-        for switchboard in self._confd.switchboards.list()['items']:
+        for switchboard in self._confd.switchboards.list(recurse=True)['items']:
             queued_calls = self._service.queued_calls(switchboard['uuid'])
             self._notifier.queued_calls(switchboard['uuid'], queued_calls)
 
     def notify_all_switchboard_held(self):
-        for switchboard in self._confd.switchboards.list()['items']:
+        for switchboard in self._confd.switchboards.list(recurse=True)['items']:
             held_calls = self._service.held_calls(switchboard['uuid'])
             self._notifier.held_calls(switchboard['uuid'], held_calls)
 

--- a/wazo_calld/plugins/switchboards/stasis.py
+++ b/wazo_calld/plugins/switchboards/stasis.py
@@ -53,8 +53,8 @@ class SwitchboardsStasis:
 
     def _stasis_start_queue(self, event_objects, event):
         try:
-            switchboard_uuid = event['args'][2]
-            tenant_uuid = event['args'][3]
+            tenant_uuid = event['args'][2]
+            switchboard_uuid = event['args'][3]
         except IndexError:
             logger.warning('Ignoring invalid StasisStart event %s', event)
             return
@@ -63,8 +63,8 @@ class SwitchboardsStasis:
 
     def _stasis_start_answer(self, event_objects, event):
         try:
-            switchboard_uuid = event['args'][2]
-            tenant_uuid = event['args'][3]
+            tenant_uuid = event['args'][2]
+            switchboard_uuid = event['args'][3]
             queued_channel_id = event['args'][4]
         except IndexError:
             logger.warning('Ignoring invalid StasisStart event %s', event)
@@ -101,8 +101,8 @@ class SwitchboardsStasis:
 
     def _stasis_start_answer_held(self, event_objects, event):
         try:
-            switchboard_uuid = event['args'][2]
-            tenant_uuid = event['args'][3]
+            tenant_uuid = event['args'][2]
+            switchboard_uuid = event['args'][3]
             held_channel_id = event['args'][4]
         except IndexError:
             logger.warning('Ignoring invalid StasisStart event %s', event)


### PR DESCRIPTION
switchboard: switch tenant_uuid/switchboard_uuid position
switchboard: use token helper to fetch user_uuid
changelog: standardize style
switchboard: add Wazo-Tenant header to documentation
switchboard: add tenant_uuid header to bus messages
switchboard: make queued_call_answered multi-tenant
switchboard: make held answer multi tenant
switchboard: make hold call multi tenant
switchboard: make answer multi tenant
switchboards: make queued_calls multi-tenant
switchboard: fix register/deregister multi-tenant
switchboard: fix styling issues