### PR TITLE
Wazo 823 sip call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   * `GET /1.0/switchboards/{switchboard_uuid}/calls/queued`
   * `PUT /1.0/switchboards/{switchboard_uuid}/calls/queued/{call_id}/answer`
 
+* The `sip_call_id` field has been added to the calls response and events
+
+
 ## 19.05
 
 * The following endpoints have been moved to wazo-chatd and deleted from wazo-calld:

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -45,7 +45,13 @@ class TestBusConsume(IntegrationTest):
     def test_when_channel_created_then_bus_event(self):
         call_id = new_call_id()
         self.ari.set_channels(MockChannel(id=call_id, connected_line_number=''))
-        self.ari.set_channel_variable({call_id: {'XIVO_BASE_EXTEN': '*10'}})
+        self.ari.set_channel_variable({
+            call_id: {
+                'XIVO_BASE_EXTEN': '*10',
+                'CHANNEL(channeltype)': 'PJSIP',
+                'CHANNEL(pjsip,call-id)': 'a-sip-call-id',
+            },
+        })
         events = self.bus.accumulator(routing_key='calls.call.created')
 
         self.bus.send_ami_newchannel_event(call_id)
@@ -58,6 +64,7 @@ class TestBusConsume(IntegrationTest):
                     'call_id': call_id,
                     'dialed_extension': '*10',
                     'peer_caller_id_number': '*10',
+                    'sip_call_id': 'a-sip-call-id',
                 })
             })))
 

--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -154,6 +154,12 @@ class Channel:
         except ARINotInStasis:
             return False
 
+    def is_sip(self):
+        try:
+            return self._get_var('CHANNEL(channeltype)') == 'PJSIP'
+        except ARINotFound:
+            return False
+
     def dialed_extension(self):
         try:
             return self._get_var('XIVO_BASE_EXTEN')
@@ -166,6 +172,15 @@ class Channel:
             return on_hold == '1'
         except ARINotFound:
             return False
+
+    def sip_call_id(self):
+        if not self.is_sip():
+            return
+
+        try:
+            return self._get_var('CHANNEL(pjsip,call-id)')
+        except ARINotFound:
+            return
 
     def _get_var(self, var):
         return self._ari.channels.getChannelVar(channelId=self.id, variable=var)['value']

--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -114,13 +114,13 @@ class Channel:
     def user(self, default=None):
         if self.is_local():
             try:
-                uuid = self._ari.channels.getChannelVar(channelId=self.id, variable='WAZO_DEREFERENCED_USERUUID')['value']
+                uuid = self._get_var('WAZO_DEREFERENCED_USERUUID')
             except ARINotFound:
                 return default
             return uuid
 
         try:
-            uuid = self._ari.channels.getChannelVar(channelId=self.id, variable='XIVO_USERUUID')['value']
+            uuid = self._get_var('XIVO_USERUUID')
             return uuid
         except ARINotFound:
             return default
@@ -142,28 +142,30 @@ class Channel:
 
     def is_caller(self):
         try:
-            direction = self._ari.channels.getChannelVar(channelId=self.id, variable='WAZO_CHANNEL_DIRECTION')['value']
+            direction = self._get_var('WAZO_CHANNEL_DIRECTION')
             return direction == 'to-wazo'
         except ARINotFound:
             return False
 
     def is_in_stasis(self):
         try:
-            self._ari.channels.setChannelVar(channelId=self.id, variable='WAZO_TEST_STASIS')
+            self._get_var('WAZO_TEST_STASIS')
             return True
         except ARINotInStasis:
             return False
 
     def dialed_extension(self):
         try:
-            result = self._ari.channels.getChannelVar(channelId=self.id, variable='XIVO_BASE_EXTEN')['value']
-            return result
+            return self._get_var('XIVO_BASE_EXTEN')
         except ARINotFound:
             return None
 
     def on_hold(self):
         try:
-            on_hold = self._ari.channels.getChannelVar(channelId=self.id, variable='XIVO_ON_HOLD')['value']
+            on_hold = self._get_var('XIVO_ON_HOLD')
             return on_hold == '1'
         except ARINotFound:
             return False
+
+    def _get_var(self, var):
+        return self._ari.channels.getChannelVar(channelId=self.id, variable=var)['value']

--- a/wazo_calld/plugins/calls/api.yml
+++ b/wazo_calld/plugins/calls/api.yml
@@ -271,6 +271,10 @@ definitions:
         description: This value is only correct when the destination of the call is a user or outgoing call. In other cases, it is always False.
       dialed_extension:
         type: string
+      sip_call_id:
+        type: string
+        description: Matches the `Call-ID` SIP header of the call. This value can be `null` when not using SIP
+        readOnly: true
   UserCallRequest:
     type: object
     properties:

--- a/wazo_calld/plugins/calls/events.yml
+++ b/wazo_calld/plugins/calls/events.yml
@@ -49,3 +49,6 @@ definitions:
       is_caller:
         type: boolean
         description: This value is only correct when the destination of the call is a user or outgoing call. In other cases, it is always False.
+      sip_call_id:
+        type: string
+        description: The value of the `Call-ID` header of `SIP` calls. Will be `null` for calls that are not `SIP`

--- a/wazo_calld/plugins/calls/schema.py
+++ b/wazo_calld/plugins/calls/schema.py
@@ -51,6 +51,7 @@ class CallSchema(Schema):
     user_uuid = fields.String()
     is_caller = fields.Boolean()
     dialed_extension = fields.String()
+    sip_call_id = fields.String()
 
     @post_dump()
     def default_peer_caller_id_number(self, call):

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -228,6 +228,7 @@ class CallsService:
                            for connected_channel in channel_helper.connected_channels()}
         call.is_caller = channel_helper.is_caller()
         call.dialed_extension = channel_helper.dialed_extension()
+        call.sip_call_id = channel_helper.sip_call_id()
 
         return call
 


### PR DESCRIPTION
calls: add the sip_call_id field
    
the sip_call_id contains the value of the Call-ID SIP header. it is used to match an event to a call started using a webrtc phone.
    
without this information the call initiator has to rely on the caller id name and number of the call to "guess" if an event is related to its phone. The guessing method also does not work with multiple calls.