### PR TITLE
Wazo 895 user application

### DIFF
--- a/integration_tests/suite/helpers/ari_.py
+++ b/integration_tests/suite/helpers/ari_.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 by Avencall
+# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -116,7 +116,14 @@ class MockChannel:
                 'name': self._connected_line_name,
                 'number': self._connected_line_number
             },
-            'name': self._name
+            'name': self._name,
+            'dialplan': {
+                'context': None,
+                'exten': None,
+                'priority': None,
+                'app_name': None,
+                'app_data': None,
+            },
         }
 
 

--- a/integration_tests/suite/helpers/chan_test.py
+++ b/integration_tests/suite/helpers/chan_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -9,6 +9,13 @@ class ChanTest:
     def __init__(self, ari_config):
         self.config = ari_config
         self._auth = (self.config['username'], self.config['password'])
+
+    def call(self, context, exten):
+        url = '{base}/ari/chan_test/new'.format(base=self.config['base_url'])
+        params = {'context': context, 'exten': exten}
+        response = requests.post(url, params=params, auth=self._auth)
+        response.raise_for_status()
+        return response
 
     def answer_channel(self, channel_id):
         url = '{base}/ari/chan_test/answer'.format(base=self.config['base_url'])

--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -162,9 +162,13 @@ class Channel:
 
     def dialed_extension(self):
         try:
-            return self._get_var('XIVO_BASE_EXTEN')
-        except ARINotFound:
             channel = self._ari.channels.get(channelId=self.id)
+        except ARINotFound:
+            return
+
+        try:
+            return channel.getChannelVar(variable='XIVO_BASE_EXTEN')['value']
+        except ARINotFound:
             return channel.json['dialplan']['exten']
 
     def on_hold(self):

--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -142,10 +142,18 @@ class Channel:
 
     def is_caller(self):
         try:
+            user_outgoing_call = self._get_var('WAZO_USER_OUTGOING_CALL')
+            return user_outgoing_call == 'true'
+        except ARINotFound:
+            pass
+
+        try:
             direction = self._get_var('WAZO_CHANNEL_DIRECTION')
             return direction == 'to-wazo'
         except ARINotFound:
-            return False
+            pass
+
+        return False
 
     def is_in_stasis(self):
         try:

--- a/wazo_calld/helpers/ari_.py
+++ b/wazo_calld/helpers/ari_.py
@@ -164,7 +164,8 @@ class Channel:
         try:
             return self._get_var('XIVO_BASE_EXTEN')
         except ARINotFound:
-            return None
+            channel = self._ari.channels.get(channelId=self.id)
+            return channel.json['dialplan']['exten']
 
     def on_hold(self):
         try:

--- a/wazo_calld/helpers/tests/test_ari_helpers.py
+++ b/wazo_calld/helpers/tests/test_ari_helpers.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from mock import (
+    Mock,
+    sentinel as s,
+)
+from hamcrest import (
+    assert_that,
+    equal_to,
+)
+
+from ari.exceptions import ARINotFound
+
+from ..ari_ import Channel
+
+
+class TestChannelHelper(TestCase):
+
+    def setUp(self):
+        self.ari = Mock()
+
+    def test_dialed_extension_when_no_channel_exist(self):
+        self.ari.channels.get.side_effect = ARINotFound(
+            original_error='no channel',
+            ari_client=self.ari,
+        )
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.dialed_extension()
+
+        assert_that(result, equal_to(None))
+
+    def test_dialed_extension_going_through_the_wazo_dialplan(self):
+        self.ari.channels.get.return_value = mocked_channel = Mock()
+        mocked_channel.getChannelVar.return_value = {'value': s.exten}
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.dialed_extension()
+
+        assert_that(result, equal_to(s.exten))
+
+    def test_dialed_extension_when_dialing_right_into_stasis(self):
+        self.ari.channels.get.return_value = mocked_channel = Mock()
+        mocked_channel.getChannelVar.side_effect = ARINotFound(
+            original_error='no var',
+            ari_client=self.ari,
+        )
+        mocked_channel.json = {'dialplan': {'exten': s.exten}}
+
+        channel = Channel(s.channel_id, self.ari)
+        result = channel.dialed_extension()
+
+        assert_that(result, equal_to(s.exten))

--- a/wazo_calld/plugins/applications/events.py
+++ b/wazo_calld/plugins/applications/events.py
@@ -163,4 +163,4 @@ class SnoopUpdated(_BaseSnoopItemEvent):
 
 class UserOutgoingCallCreated(_BaseCallItemEvent):
     name = 'application_user_outgoing_call_created'
-    routing_key = 'applications.{}.useroutgoingcall.{}.created'
+    routing_key = 'applications.{}.user_outgoing_call.{}.created'

--- a/wazo_calld/plugins/applications/events.py
+++ b/wazo_calld/plugins/applications/events.py
@@ -159,3 +159,8 @@ class SnoopDeleted(_BaseSnoopItemEvent):
 class SnoopUpdated(_BaseSnoopItemEvent):
     name = 'application_snoop_updated'
     routing_key = 'applications.{}.snoops.{}.updated'
+
+
+class UserOutgoingCallCreated(_BaseCallItemEvent):
+    name = 'application_user_outgoing_call_created'
+    routing_key = 'applications.{}.useroutgoingcall.{}.created'

--- a/wazo_calld/plugins/applications/notifier.py
+++ b/wazo_calld/plugins/applications/notifier.py
@@ -25,6 +25,7 @@ from .events import (
     SnoopCreated,
     SnoopDeleted,
     SnoopUpdated,
+    UserOutgoingCallCreated,
 )
 
 logger = logging.getLogger(__name__)
@@ -122,4 +123,13 @@ class ApplicationNotifier:
         logger.debug('Application (%s): Snoop (%s) updated', application_uuid, snoop.uuid)
         snoop = application_snoop_schema.dump(snoop).data
         event = SnoopUpdated(application_uuid, snoop)
+        self._bus.publish(event)
+
+    def user_outgoing_call_created(self, application_uuid, call):
+        logger.debug(
+            'Application (%s): User outgoing call (%s) created',
+            application_uuid, call.id_,
+        )
+        call = application_call_schema.dump(call).data
+        event = UserOutgoingCallCreated(application_uuid, call)
         self._bus.publish(event)

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -73,10 +73,11 @@ class ApplicationService:
         channel.answer()
 
     def start_user_outgoing_call(self, application, channel):
+        self.set_channel_var_sync(channel, 'WAZO_USER_OUTGOING_CALL', 'true')
         variables = self.get_channel_variables(channel)
         formatter = CallFormatter(application, self._ari)
         call = formatter.from_channel(channel, variables=variables)
-        self._notifier.call_entered(application['uuid'], call)
+        self._notifier.user_outgoing_call_created(application['uuid'], call)
 
     def create_destination_node(self, application):
         try:

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -72,7 +72,7 @@ class ApplicationService:
 
         channel.answer()
 
-    def channel_user_entered(self, application, channel):
+    def start_user_outgoing_call(self, application, channel):
         variables = self.get_channel_variables(channel)
         formatter = CallFormatter(application, self._ari)
         call = formatter.from_channel(channel, variables=variables)

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -72,6 +72,12 @@ class ApplicationService:
 
         channel.answer()
 
+    def channel_user_entered(self, application, channel):
+        variables = self.get_channel_variables(channel)
+        formatter = CallFormatter(application, self._ari)
+        call = formatter.from_channel(channel, variables=variables)
+        self._notifier.call_entered(application['uuid'], call)
+
     def create_destination_node(self, application):
         try:
             bridge = self._ari.bridges.get(bridgeId=application['uuid'])

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -442,8 +442,10 @@ class ApplicationService:
         def get_value():
             try:
                 return channel.getChannelVar(variable=var)['value']
-            except ARINotFound:
-                return None
+            except ARINotFound as e:
+                if e.original_error.response.reason == 'Variable Not Found':
+                    return None
+                raise
 
         channel.setChannelVar(variable=var, value=value)
         for _ in range(20):

--- a/wazo_calld/plugins/applications/services.py
+++ b/wazo_calld/plugins/applications/services.py
@@ -453,7 +453,7 @@ class ApplicationService:
                 return
 
             logger.debug('waiting for a setvar to complete')
-            time.sleep(0.001)
+            time.sleep(0.01)
 
         raise Exception('failed to set channel variable {}={}'.format(var, value))
 

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -218,7 +218,7 @@ class ApplicationStasis:
         channel = event_objects['channel']
         logger.debug('new incoming call user %s', channel.id)
         application = self._service.get_application(application_uuid)
-        self._service.channel_user_entered(application, channel)
+        self._service.start_user_outgoing_call(application, channel)
 
     def _stasis_start_originate(self, application_uuid, node_uuid, event_objects, event):
         channel = event_objects['channel']

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -93,7 +93,7 @@ class ApplicationStasis:
             return
 
         if not event['args']:
-            return self._stasis_start_user(application_uuid, event_objects, event)
+            return self._stasis_start_user_outgoing(application_uuid, event_objects, event)
 
         command, *command_args = event['args']
         if command == 'incoming':
@@ -214,7 +214,7 @@ class ApplicationStasis:
         if confd_application['destination'] == 'node':
             self._service.join_destination_node(channel, confd_application)
 
-    def _stasis_start_user(self, application_uuid, event_objects, event):
+    def _stasis_start_user_outgoing(self, application_uuid, event_objects, event):
         channel = event_objects['channel']
         logger.debug('new incoming call user %s', channel.id)
         application = self._service.get_application(application_uuid)

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -216,7 +216,7 @@ class ApplicationStasis:
 
     def _stasis_start_user_outgoing(self, application_uuid, event_objects, event):
         channel = event_objects['channel']
-        logger.debug('new incoming call user %s', channel.id)
+        logger.debug('new user outgoing call %s', channel.id)
         application = self._service.get_application(application_uuid)
         self._service.start_user_outgoing_call(application, channel)
 

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -88,21 +88,19 @@ class ApplicationStasis:
         logger.debug('Stasis applications initialized')
 
     def stasis_start(self, event_objects, event):
-        args = event.get('args', [])
         application_uuid = AppNameHelper.to_uuid(event.get('application'))
-        if application_uuid and len(args) < 1:
-            args = ['user']
-        if not application_uuid or len(args) < 1:
+        if not application_uuid:
             return
 
-        command = args[0]
+        if not event['args']:
+            return self._stasis_start_user(application_uuid, event_objects, event)
+
+        command, *command_args = event['args']
         if command == 'incoming':
             self._stasis_start_incoming(application_uuid, event_objects, event)
         elif command == 'originate':
-            node_uuid = args[1] if len(args) > 1 else None
+            node_uuid = command_args[0] if command_args else None
             self._stasis_start_originate(application_uuid, node_uuid, event_objects, event)
-        elif command == 'user':
-            self._stasis_start_user(application_uuid, event_objects, event)
 
     def stasis_end(self, channel, event):
         application_uuid = AppNameHelper.to_uuid(event.get('application'))

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -90,6 +90,8 @@ class ApplicationStasis:
     def stasis_start(self, event_objects, event):
         args = event.get('args', [])
         application_uuid = AppNameHelper.to_uuid(event.get('application'))
+        if application_uuid and len(args) < 1:
+            args = ['user']
         if not application_uuid or len(args) < 1:
             return
 
@@ -99,6 +101,8 @@ class ApplicationStasis:
         elif command == 'originate':
             node_uuid = args[1] if len(args) > 1 else None
             self._stasis_start_originate(application_uuid, node_uuid, event_objects, event)
+        elif command == 'user':
+            self._stasis_start_user(application_uuid, event_objects, event)
 
     def stasis_end(self, channel, event):
         application_uuid = AppNameHelper.to_uuid(event.get('application'))
@@ -211,6 +215,12 @@ class ApplicationStasis:
         confd_application = self._service.get_confd_application(application_uuid)
         if confd_application['destination'] == 'node':
             self._service.join_destination_node(channel, confd_application)
+
+    def _stasis_start_user(self, application_uuid, event_objects, event):
+        channel = event_objects['channel']
+        logger.debug('new incoming call user %s', channel.id)
+        application = self._service.get_application(application_uuid)
+        self._service.channel_user_entered(application, channel)
 
     def _stasis_start_originate(self, application_uuid, node_uuid, event_objects, event):
         channel = event_objects['channel']

--- a/wazo_calld/plugins/applications/tests/test_stasis.py
+++ b/wazo_calld/plugins/applications/tests/test_stasis.py
@@ -1,0 +1,87 @@
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+
+from hamcrest import (
+    assert_that,
+    calling,
+    not_,
+)
+from mock import (
+    Mock,
+    patch,
+    sentinel as s,
+)
+from xivo_test_helpers.hamcrest.raises import raises
+
+from ..stasis import ApplicationStasis
+
+
+class TestApplicationStasisStartHandler(TestCase):
+
+    def setUp(self):
+        self.ari = Mock()
+        self.confd = Mock()
+        self.service = Mock()
+        self.notifier = Mock()
+
+        self.app = ApplicationStasis(self.ari, self.confd, self.service, self.notifier)
+
+    def test_stasis_start_no_a_wazo_app(self):
+        event = {'application': 'foobar'}
+
+        assert_that(
+            calling(self.app.stasis_start).with_args(s.event_object, event),
+            not_(raises(Exception)),
+        )
+        self.app.stasis_start(s.event_object, event)
+
+    def test_stasis_start_user_outgoing_call(self):
+        uuid = 'e3f9b7ef-3fa7-4240-88f1-e6f5c0945b9b'
+        event = {
+            'application': 'wazo-app-{}'.format(uuid),
+            'args': [],
+        }
+
+        with patch.object(self.app, '_stasis_start_user') as fn:
+            self.app.stasis_start(s.event_object, event)
+
+            fn.assert_called_once_with(uuid, s.event_object, event)
+
+    def test_stasis_start_incoming_call(self):
+        uuid = 'e3f9b7ef-3fa7-4240-88f1-e6f5c0945b9b'
+        event = {
+            'application': 'wazo-app-{}'.format(uuid),
+            'args': ['incoming'],
+        }
+
+        with patch.object(self.app, '_stasis_start_incoming') as fn:
+            self.app.stasis_start(s.event_object, event)
+
+            fn.assert_called_once_with(uuid, s.event_object, event)
+
+    def test_stasis_start_originate_in_node(self):
+        uuid = 'e3f9b7ef-3fa7-4240-88f1-e6f5c0945b9b'
+        node_uuid = 'a39a50e5-b5dc-4816-ab6a-1c5b9305e513'
+        event = {
+            'application': 'wazo-app-{}'.format(uuid),
+            'args': ['originate', node_uuid],
+        }
+
+        with patch.object(self.app, '_stasis_start_originate') as fn:
+            self.app.stasis_start(s.event_object, event)
+
+            fn.assert_called_once_with(uuid, node_uuid, s.event_object, event)
+
+    def test_stasis_start_originate_no_node(self):
+        uuid = 'e3f9b7ef-3fa7-4240-88f1-e6f5c0945b9b'
+        event = {
+            'application': 'wazo-app-{}'.format(uuid),
+            'args': ['originate']
+        }
+
+        with patch.object(self.app, '_stasis_start_originate') as fn:
+            self.app.stasis_start(s.event_object, event)
+
+            fn.assert_called_once_with(uuid, None, s.event_object, event)

--- a/wazo_calld/plugins/applications/tests/test_stasis.py
+++ b/wazo_calld/plugins/applications/tests/test_stasis.py
@@ -35,7 +35,6 @@ class TestApplicationStasisStartHandler(TestCase):
             calling(self.app.stasis_start).with_args(s.event_object, event),
             not_(raises(Exception)),
         )
-        self.app.stasis_start(s.event_object, event)
 
     def test_stasis_start_user_outgoing_call(self):
         uuid = 'e3f9b7ef-3fa7-4240-88f1-e6f5c0945b9b'

--- a/wazo_calld/plugins/applications/tests/test_stasis.py
+++ b/wazo_calld/plugins/applications/tests/test_stasis.py
@@ -44,7 +44,7 @@ class TestApplicationStasisStartHandler(TestCase):
             'args': [],
         }
 
-        with patch.object(self.app, '_stasis_start_user') as fn:
+        with patch.object(self.app, '_stasis_start_user_outgoing') as fn:
             self.app.stasis_start(s.event_object, event)
 
             fn.assert_called_once_with(uuid, s.event_object, event)

--- a/wazo_calld/plugins/calls/event.py
+++ b/wazo_calld/plugins/calls/event.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import iso8601
@@ -40,9 +40,8 @@ class StartCallEvent(CallEvent):
     def _get_app(self):
         if 'args' not in self._event:
             raise InvalidStartCallEvent()
-        if len(self._event['args']) < 1:
-            raise InvalidStartCallEvent()
-        return self._event['application'], self._event['args'][0]
+        first_arg = self._event['args'][0] if self._event['args'] else None
+        return self._event['application'], first_arg
 
 
 class ConnectCallEvent(StartCallEvent):

--- a/wazo_calld/plugins/calls/tests/test_event.py
+++ b/wazo_calld/plugins/calls/tests/test_event.py
@@ -1,4 +1,4 @@
-# Copyright 2016 by Avencall
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ari.exceptions import ARINotFound
@@ -71,10 +71,6 @@ class TestStartCallEvent(TestCase):
                                                       event={},
                                                       state_persistor=Mock()),
                     raises(InvalidStartCallEvent))
-        assert_that(calling(StartCallEvent).with_args(channel=Mock(),
-                                                      event={'args': []},
-                                                      state_persistor=Mock()),
-                    raises(InvalidStartCallEvent))
 
     def test_get_stasis_start_app_valid(self):
         event = {
@@ -88,6 +84,17 @@ class TestStartCallEvent(TestCase):
 
         assert_that(result.app, equal_to('myapp'))
         assert_that(result.app_instance, equal_to('red'))
+
+    def test_get_stasis_start_app_valid_no_argument(self):
+        event = {
+            'application': 'myapp',
+            'args': [],
+        }
+
+        result = StartCallEvent(channel=Mock(), event=event, state_persistor=Mock())
+
+        assert_that(result.app, equal_to('myapp'))
+        assert_that(result.app_instance, equal_to(None))
 
 
 class TestConnectCallEvent(TestCase):


### PR DESCRIPTION
add a `StasisStart` handler for applications with no command which are used for users with lines calling directly into Wazo applications.