### PR TITLE
applications: add the user_uuid and tenant_uuid to the call body

### DIFF
--- a/wazo_calld/plugins/applications/models.py
+++ b/wazo_calld/plugins/applications/models.py
@@ -19,6 +19,8 @@ class ApplicationCall:
         self.id_ = id_
         self.moh_uuid = None
         self.muted = False
+        self.user_uuid = None
+        self.tenant_uuid = None
 
 
 class ApplicationNode:
@@ -55,6 +57,16 @@ class CallFormatter:
                 call.moh_uuid = channel.getChannelVar(variable='WAZO_MOH_UUID').get('value') or None
             except ARINotFound:
                 call.moh_uuid = None
+
+            try:
+                call.user_uuid = channel.getChannelVar(variable='XIVO_USERUUID').get('value')
+            except ARINotFound:
+                call.user_uuid = None
+
+            try:
+                call.tenant_uuid = channel.getChannelVar(variable='WAZO_TENANT_UUID').get('value')
+            except ARINotFound:
+                call.tenant_uuid = None
 
             try:
                 call.muted = channel.getChannelVar(variable='WAZO_CALL_MUTED').get('value') == '1'

--- a/wazo_calld/plugins/applications/schema.py
+++ b/wazo_calld/plugins/applications/schema.py
@@ -62,6 +62,8 @@ class ApplicationCallSchema(BaseSchema):
     moh_uuid = fields.String()
     muted = fields.Boolean()
     snoops = fields.Dict(dump_only=True)
+    user_uuid = fields.String()
+    tenant_uuid = fields.String()
 
 
 class ApplicationNodeCallSchema(BaseSchema):


### PR DESCRIPTION
when a call event is published the user_uuid and tenant_uuid fields will be set
if the channel has the appropriate channel variables