### PR TITLE
application: do not subscribe many time on app events

### DIFF
--- a/wazo_calld/ari_.py
+++ b/wazo_calld/ari_.py
@@ -111,7 +111,8 @@ class CoreARI:
             self._apps.append(app)
 
     def deregister_application(self, app):
-        self._apps.pop(app, None)
+        if app in self._apps:
+            self._apps.remove(app)
 
     def is_running(self):
         return self._is_running

--- a/wazo_calld/ari_.py
+++ b/wazo_calld/ari_.py
@@ -42,9 +42,11 @@ class CoreARI:
         self._is_running = False
         self._should_delay_reconnect = True
         self._should_stop = False
-        self.client = self._new_ari_client(config['connection'],
-                                           config['startup_connection_tries'],
-                                           config['startup_connection_delay'])
+        self.client = self._new_ari_client(
+            config['connection'],
+            config['startup_connection_tries'],
+            config['startup_connection_delay'],
+        )
 
     def _new_ari_client(self, ari_config, connection_tries, connection_delay):
         for _ in range(connection_tries):
@@ -108,8 +110,8 @@ class CoreARI:
         if app not in self._apps:
             self._apps.append(app)
 
-    def clear_applications(self):
-        self._apps = []
+    def deregister_application(self, app):
+        self._apps.pop(app, None)
 
     def is_running(self):
         return self._is_running

--- a/wazo_calld/plugins/applications/plugin.py
+++ b/wazo_calld/plugins/applications/plugin.py
@@ -79,9 +79,9 @@ class Plugin:
             moh_cache,
         )
         next_token_changed_subscribe(stasis.initialize)
-        confd_apps_cache.created_subscribe(stasis.reinitialize)
+        confd_apps_cache.created_subscribe(stasis.add_ari_application)
         confd_apps_cache.updated_subscribe(service.update_destination_node)
-        confd_apps_cache.deleted_subscribe(stasis.reinitialize)
+        confd_apps_cache.deleted_subscribe(stasis.remove_ari_application)
 
         api.add_resource(
             ApplicationItem,

--- a/wazo_calld/plugins/applications/stasis.py
+++ b/wazo_calld/plugins/applications/stasis.py
@@ -99,11 +99,11 @@ class ApplicationStasis:
 
     def remove_ari_application(self, application):
         app_name = AppNameHelper.to_name(application['uuid'])
-        self.client._ari.on_application_deregistered(app_name, self._on_websocket_stop)
+        self._ari.on_application_deregistered(app_name, self._on_websocket_stop)
 
         # Should be implemented in ari-py
-        self.client._app_registered_callbacks.pop(app_name, None)
-        self.client._app_deregistered_callbacks.pop(app_name, None)
+        self._ari._app_registered_callbacks.pop(app_name, None)
+        self._ari._app_deregistered_callbacks.pop(app_name, None)
 
         self._core_ari.deregister_application(app_name)
         self._core_ari.reload()


### PR DESCRIPTION
reason: if subscribe() is call more than one time, then ari-py will
trigger callback many time.