### PR TITLE
call_ended: add the sip_call_id field

### DIFF
--- a/integration_tests/assets/etc/asterisk/manager.conf
+++ b/integration_tests/assets/etc/asterisk/manager.conf
@@ -3,7 +3,7 @@ enabled = yes
 webenabled = yes
 port = 5038
 bindaddr = 0.0.0.0
-channelvars=XIVO_USERUUID
+channelvars=XIVO_USERUUID,WAZO_SIP_CALL_ID
 
 [xivo_amid]
 secret = opensesame

--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -83,7 +83,7 @@ class BusClient(bus_helper.BusClient):
             }
         }, 'ami.Unhold')
 
-    def send_ami_hangup_event(self, channel_id, base_exten=None):
+    def send_ami_hangup_event(self, channel_id, base_exten=None, sip_call_id=None):
         self.send_event({
             'data': {
                 'Event': 'Hangup',
@@ -96,6 +96,7 @@ class BusClient(bus_helper.BusClient):
                 'ChanVariable': {
                     'XIVO_USERUUID': 'my-uuid',
                     'XIVO_BASE_EXTEN': base_exten if base_exten else '*10',
+                    'WAZO_SIP_CALL_ID': sip_call_id,
                 },
             }
         }, 'ami.Hangup')

--- a/integration_tests/suite/test_calls_bus_consume.py
+++ b/integration_tests/suite/test_calls_bus_consume.py
@@ -37,6 +37,27 @@ class TestBusConsume(IntegrationTest):
                 'data': has_entries({
                     'call_id': call_id,
                     'dialed_extension': '*10',
+                    'sip_call_id': None,
+                })
+            })))
+
+        until.assert_(assert_function, tries=5)
+
+    def test_when_channel_ended_with_sip_call_id_then_bus_event(self):
+        call_id = new_call_id()
+        sip_call_id = 'foobar'
+        events = self.bus.accumulator(routing_key='calls.call.ended')
+
+        self.bus.send_ami_hangup_event(call_id, base_exten='*10', sip_call_id=sip_call_id)
+
+        def assert_function():
+            assert_that(events.accumulate(), has_item(has_entries({
+                'name': 'call_ended',
+                'origin_uuid': XIVO_UUID,
+                'data': has_entries({
+                    'call_id': call_id,
+                    'dialed_extension': '*10',
+                    'sip_call_id': sip_call_id,
                 })
             })))
 

--- a/wazo_calld/plugins/calls/services.py
+++ b/wazo_calld/plugins/calls/services.py
@@ -244,5 +244,6 @@ class CallsService:
         call.dialed_extension = event_variables.get('XIVO_BASE_EXTEN') or None
         call.bridges = []
         call.talking_to = {}
+        call.sip_call_id = event_variables.get('WAZO_SIP_CALL_ID') or None
 
         return call


### PR DESCRIPTION
When a call is created the sip_call_id is assigned to the WAZO_SIP_CALL_ID
channel variable. Then when the hangup AMI event is received containing this
variable the call_ended event can be populated from this variable.

the channel helper sip_call_id function cannot be used at this point since the
channel has already disappeared